### PR TITLE
ENH: fix #26, improve #21 (baseline selection, and replace VTK filters)

### DIFF
--- a/Modules/CLI/DiffusionWeightedVolumeMasking/CMakeLists.txt
+++ b/Modules/CLI/DiffusionWeightedVolumeMasking/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 #-----------------------------------------------------------------------------
 set(MODULE_NAME DiffusionWeightedVolumeMasking)
 
@@ -13,22 +12,22 @@ include_directories(BEFORE ${vtkTeem_INCLUDE_DIRS})
 find_package(SlicerExecutionModel REQUIRED)
 include(${SlicerExecutionModel_USE_FILE})
 
-#
-# VTK
-#
-#find_package(VTK REQUIRED)
-#include(${VTK_USE_FILE})
-
 #-----------------------------------------------------------------------------
 set(${MODULE_NAME}_TARGET_LIBRARIES
-  MRMLCore vtkTeem vtkSlicerEditorLibModuleLogic ${VTK_LIBRARIES}
+  MRMLCore vtkTeem ${VTK_LIBRARIES}
   )
+
+#-----------------------------------------------------------------------------
+# NOTE: this must be changed for future ITK versions
+set(ITK_SOURCE_PATH ${Slicer_HOME}/../ITKv4/)
 
 #-----------------------------------------------------------------------------
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${Slicer_SOURCE_DIR}/Resources/ITKLogo.h
   INCLUDE_DIRECTORIES
+    ${ITK_SOURCE_PATH}/Modules/Bridge/VTK/include
+    ${ITK_SOURCE_PATH}/Modules/Bridge/VtkGlue/include
     ${vtkITK_INCLUDE_DIRS}
     ${MRMLCore_INCLUDE_DIRS}
     ${vtkTeem_INCLUDE_DIRS}

--- a/Modules/CLI/DiffusionWeightedVolumeMasking/DiffusionWeightedVolumeMasking.cxx
+++ b/Modules/CLI/DiffusionWeightedVolumeMasking/DiffusionWeightedVolumeMasking.cxx
@@ -30,8 +30,6 @@
 
 #include "DiffusionWeightedVolumeMaskingCLP.h"
 
-#define GRAD_0_TOL 1e-6
-
 int main( int argc, char * argv[] )
 {
 
@@ -63,14 +61,14 @@ int main( int argc, char * argv[] )
     imageWeightedSum->NormalizeByWeightOn();
 
     int b0_count = 0;
-    for( int gradient_n = 0; gradient_n < grads->GetNumberOfTuples(); gradient_n++ )
+    for( int bval_n = 0; bval_n < bValues->GetNumberOfTuples(); bval_n++ )
       {
-      double* gradient = grads->GetTuple3(gradient_n);
-      if( fabs(gradient[0]) + fabs(gradient[1]) + fabs(gradient[2]) < GRAD_0_TOL )
+      double bvalue = bValues->GetTuple1(bval_n);
+      if( bvalue <= baselineBValueThreshold )
         {
         vtkNew<vtkImageExtractComponents> extractComponents;
         extractComponents->SetInputConnection(reader->GetOutputPort() );
-        extractComponents->SetComponents(gradient_n);
+        extractComponents->SetComponents(bval_n);
         extractComponents->Update();
 
         imageWeightedSum->AddInputConnection(extractComponents->GetOutputPort() );

--- a/Modules/CLI/DiffusionWeightedVolumeMasking/DiffusionWeightedVolumeMasking.xml
+++ b/Modules/CLI/DiffusionWeightedVolumeMasking/DiffusionWeightedVolumeMasking.xml
@@ -35,19 +35,6 @@
   </parameters>
   <parameters>
     <double>
-      <name>otsuOmegaThreshold</name>
-      <label>Otsu Omega Threshold Parameter</label>
-      <flag>o</flag>
-      <longflag>otsuomegathreshold</longflag>
-      <description><![CDATA[Control the sharpness of the threshold in the Otsu computation. 0: lower threshold, 1: higher threhold]]></description>
-      <default>0.5</default>
-      <constraints>
-        <minimum>0.0</minimum>
-        <maximum>1.0</maximum>
-        <step>0.1</step>
-      </constraints>
-    </double>
-    <double>
       <name>baselineBValueThreshold</name>
       <label>Baseline B-Value Threshold Parameter</label>
       <flag>b</flag>

--- a/Modules/CLI/DiffusionWeightedVolumeMasking/DiffusionWeightedVolumeMasking.xml
+++ b/Modules/CLI/DiffusionWeightedVolumeMasking/DiffusionWeightedVolumeMasking.xml
@@ -47,6 +47,18 @@
         <step>0.1</step>
       </constraints>
     </double>
+    <double>
+      <name>baselineBValueThreshold</name>
+      <label>Baseline B-Value Threshold Parameter</label>
+      <flag>b</flag>
+      <longflag>baselineBValueThreshold</longflag>
+      <description><![CDATA[Volumes with B-value below this threshold will be considered baseline images and included in mask calculation.]]></description>
+      <default>100</default>
+      <constraints>
+        <minimum>0.0</minimum>
+        <step>1</step>
+      </constraints>
+    </double>
     <boolean>
       <name>removeIslands</name>
       <label>Remove Islands in Threshold Mask</label>


### PR DESCRIPTION
Fixes https://github.com/SlicerDMRI/SlicerDMRI/issues/26 by selecting
baseline images using a threshold on the B-values rather than gradient
magnitude. Provides command line option to select threshold if needed
(default 100).

Prior to the change in [1], all images were potentially included in the mask
calculation because gradient components were rounded down
to zero [2]. After [1], some datasets are rejected because the 1e-6
tolerance criteria excludes low (non-zero) B-value volumes. For example,
in the issue #26 dataset, the baseline volumes have B-value 5.

[1] https://github.com/Slicer/Slicer/pull/380
[2] http://www.na-mic.org/Bug/view.php?id=3855