### PR TITLE
COMP: CompareTxts: Fix build errors

### DIFF
--- a/Modules/CLI/FiberTractMeasurements/Testing/CompareTxts.cxx
+++ b/Modules/CLI/FiberTractMeasurements/Testing/CompareTxts.cxx
@@ -7,6 +7,7 @@
 #endif
 
 // STD includes
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -22,8 +23,8 @@ int main( int argc, char * argv[] )
 
   std::string resultTxtPath = argv[1];
   std::string baselineTxtPath = argv[2];
-  std::ifstream resultTxt(resultTxtPath);
-  std::ifstream baselineTxt(baselineTxtPath);
+  std::ifstream resultTxt(resultTxtPath.c_str());
+  std::ifstream baselineTxt(baselineTxtPath.c_str());
 
   std::string resultLine;
   std::string baselineLine;


### PR DESCRIPTION
1) Include "cstdlib" to fix this build error:

```
/home/jcfr/Projects/Slicer-Debug/DMRI/FiberTractMeasurements/Testing/CompareTxts.cxx: In function ‘int main(int, char**)’:
/home/jcfr/Projects/Slicer-Debug/DMRI/FiberTractMeasurements/Testing/CompareTxts.cxx:20:12: error: ‘EXIT_FAILURE’ was not declared in this scope
     return EXIT_FAILURE;
            ^
```

2) Construct "ifstream" using char* signature  also available with c++ older
that c++11:

```
/home/jcfr/Projects/Slicer-Debug/DMRI/FiberTractMeasurements/Testing/CompareTxts.cxx:25:40: error: no matching function for call to ‘std::basic_ifstream<char>::basic_ifstream(std::__cxx11::string&)’
   std::ifstream resultTxt(resultTxtPath);
                                        ^
```