### PR TITLE
BUG: Make sure to link against CLI library in testing

### DIFF
--- a/Modules/CLI/DWIToDTIEstimation/Testing/CMakeLists.txt
+++ b/Modules/CLI/DWIToDTIEstimation/Testing/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(
 add_executable(${CLP}Test ${CLP}Test.cxx)
 add_dependencies(${CLP}Test ${CLP})
 target_link_libraries(${CLP}Test
+  ${CLP}Lib
   ${${MODULE_NAME}_TARGET_LIBRARIES}
   ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES}
   )

--- a/Modules/CLI/DiffusionTensorScalarMeasurements/Testing/CMakeLists.txt
+++ b/Modules/CLI/DiffusionTensorScalarMeasurements/Testing/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CLP ${MODULE_NAME})
 add_executable(${CLP}Test ${CLP}Test.cxx)
 add_dependencies(${CLP}Test ${CLP})
 target_link_libraries(${CLP}Test
+  ${CLP}Lib
   ${${MODULE_NAME}_TARGET_LIBRARIES}
   ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES}
   )


### PR DESCRIPTION
A little background for this pull request:

I am currently working on integrating the parameter serializer in Slicer. While integrating JsonCpp to the SlicerExecutionModel as a first step, I had link errors because of the missing libraries in the testing. This pulls request fixes that.

For more information, see https://www.slicer.org/slicerWiki/index.php/Documentation/Labs/ParameterSerializer

Thanks !