### PR TITLE
ENH: Added edit node support to tractography interactive seeding

### DIFF
--- a/Modules/Loadable/InteractiveSeeding/Logic/vtkSlicerTractographyInteractiveSeedingLogic.cxx
+++ b/Modules/Loadable/InteractiveSeeding/Logic/vtkSlicerTractographyInteractiveSeedingLogic.cxx
@@ -25,8 +25,9 @@
 #include <vtkMRMLMarkupsFiducialNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLScalarVolumeNode.h>
-#include "vtkMRMLTractographyInteractiveSeedingNode.h"
 #include <vtkMRMLTransformNode.h>
+#include <vtkMRMLSubjectHierarchyNode.h>
+#include "vtkMRMLTractographyInteractiveSeedingNode.h"
 
 // vtkTeem includes
 #include <vtkDiffusionTensorMathematics.h>
@@ -656,6 +657,14 @@ void vtkSlicerTractographyInteractiveSeedingLogic
                      snode->GetSeedSelectedFiducials(),
                      snode->GetDisplayMode()
                      );
+
+  // Make sure output fiber node is under the DTI volume in subject hierarchy
+  vtkMRMLSubjectHierarchyNode* shNode =
+    vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(this->GetMRMLScene());
+  if (shNode)
+    {
+    shNode->CreateItem(shNode->GetItemByDataNode(volumeNode), fiberNode);
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.cxx
+++ b/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.cxx
@@ -8,6 +8,8 @@
 #include "vtkMRMLDiffusionTensorVolumeNode.h"
 #include "vtkMRMLAnnotationHierarchyNode.h"
 #include "vtkMRMLAnnotationFiducialNode.h"
+#include "vtkMRMLMarkupsFiducialNode.h"
+#include "vtkMRMLLabelMapVolumeNode.h"
 #include "vtkMRMLScene.h"
 
 // Tractography Logic includes
@@ -817,4 +819,43 @@ void qSlicerTractographyInteractiveSeedingModuleWidget::toggleEnableInteractiveS
 
   this->setEnableSeeding(state);
   d->EnableSeedingCheckBox->setChecked(state);
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerTractographyInteractiveSeedingModuleWidget::setEditedNode(
+  vtkMRMLNode* node, QString role/*=QString()*/, QString context/*=QString()*/ )
+{
+  Q_D(qSlicerTractographyInteractiveSeedingModuleWidget);
+  if (vtkMRMLDiffusionTensorVolumeNode::SafeDownCast(node))
+    {
+    d->DTINodeSelector->setCurrentNode(node);
+    return true;
+    }
+  else if ( vtkMRMLMarkupsFiducialNode::SafeDownCast(node)
+    || vtkMRMLAnnotationHierarchyNode::SafeDownCast(node)
+    || vtkMRMLModelNode::SafeDownCast(node)
+    || vtkMRMLLabelMapVolumeNode::SafeDownCast(node) )
+    {
+    d->FiducialNodeSelector->setCurrentNode(node);
+    return true;
+    }
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerTractographyInteractiveSeedingModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLDiffusionTensorVolumeNode::SafeDownCast(node))
+    {
+    return 0.9;
+    }
+  else if ( vtkMRMLMarkupsFiducialNode::SafeDownCast(node)
+    || vtkMRMLAnnotationHierarchyNode::SafeDownCast(node)
+    || vtkMRMLModelNode::SafeDownCast(node)
+    || vtkMRMLLabelMapVolumeNode::SafeDownCast(node) )
+    {
+    return 0.6;
+    }
+
+  return 0.0;
 }

--- a/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.h
+++ b/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.h
@@ -38,14 +38,20 @@ public:
   /// Get current DTI volume node
   vtkMRMLDiffusionTensorVolumeNode* diffusionTensorVolumeNode();
 
-  /// Get current fiber bundlde node
+  /// Get current fiber bundle node
   vtkMRMLFiberBundleNode* fiberBundleNode();
+
+  /// Support of node editing. Select node in GUI that the user wants to edit.
+  /// No need for roles, as node type unambiguously determines role in this module
+  virtual bool setEditedNode(
+    vtkMRMLNode* node, QString role=QString(), QString context=QString() );
+  /// Return confidence value for nodes based on how suitable they are to edit
+  virtual double nodeEditable(vtkMRMLNode* node);
 
   virtual void enter();
 
 public slots:
 
-  ///
   /// Set the current MRML scene to the widget
   virtual void setMRMLScene(vtkMRMLScene*);
 
@@ -56,8 +62,8 @@ public slots:
 
   /// Set parameter node to one of resets:
   /// 0 - Slicer4
-  /// 1- Slicer3 FiducialSeeding module
-  /// 2- Slicer3 Labe Map Seeding module
+  /// 1 - Slicer3 FiducialSeeding module
+  /// 2 - Slicer3 LabelMap Seeding module
   void setParametersPreset(int index);
 
   /// Set current parameter node
@@ -111,7 +117,7 @@ public slots:
   /// Set [ThresholdMode] start threshold
   void setStartThreshold(double value);
 
-  /// Set RPO label from Qt widgjet
+  /// Set RPO label from Qt widget
   void setROILabels();
 
   /// Set RPO label from string


### PR DESCRIPTION
The feature allows setting nodes to their proper places in the GUI.
Subject hierarchy support also added so that output fiber tract is placed under the DTI volume in the hierarchy