### PR TITLE
BUG/ENH: use enums for UI<->SeedingNode settings

### DIFF
--- a/Libs/vtkDMRI/vtkSeedTracts.cxx
+++ b/Libs/vtkDMRI/vtkSeedTracts.cxx
@@ -658,7 +658,16 @@ void vtkSeedTracts::SeedStreamlinesInROI()
                       // compute eigensystem
                       //vtkMath::Jacobi(m, w, v);
                       vtkDiffusionTensorMathematics::TeemEigenSolver(m,w,v);
-                      double cl = vtkDiffusionTensorMathematics::LinearMeasure(w);
+                      double cl = 0.0;
+                      if (this->VtkHyperStreamlinePointsSettings->GetThresholdMode() ==
+                          vtkDiffusionTensorMathematics::VTK_TENS_FRACTIONAL_ANISOTROPY)
+                        {
+                        cl = vtkDiffusionTensorMathematics::FractionalAnisotropy(w);
+                        }
+                      else // vtkDiffusionTensorMathematics::VTK_TENS_LINEAR_MEASURE
+                        {
+                        cl = vtkDiffusionTensorMathematics::LinearMeasure(w);
+                        }
                       if (cl < this->StartingThreshold)
                         {
                         continue;

--- a/Modules/CLI/TractographyLabelMapSeeding/TractographyLabelMapSeeding.xml
+++ b/Modules/CLI/TractographyLabelMapSeeding/TractographyLabelMapSeeding.xml
@@ -144,13 +144,14 @@
   </parameters>
 
   <parameters advanced="true">
+    <label>Advanced</label>
     <boolean>
       <name>UseIndexSpace</name>
       <label>Use Index Space</label>
       <flag>-x</flag>
       <longflag>--useindexspace</longflag>
       <description><![CDATA[Seed at IJK voxel grid]]></description>
-      <default>false</default>
+      <default>true</default>
     </boolean>
 
     <double>

--- a/Modules/CLI/TractographyLabelMapSeeding/TractographyLabelMapSeeding.xml
+++ b/Modules/CLI/TractographyLabelMapSeeding/TractographyLabelMapSeeding.xml
@@ -39,7 +39,7 @@
     <description><![CDATA[Options for seed placement]]></description>
     <double>
       <name>ClTh</name>
-      <label>Linear Measure Start Threshold</label>
+      <label>Start Threshold</label>
       <flag>-c</flag>
       <longflag>--clthreshold</longflag>
       <description><![CDATA[Minimum Linear Measure for the seeding to start.]]></description>

--- a/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.cxx
+++ b/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.cxx
@@ -31,7 +31,7 @@ vtkMRMLNodeNewMacro(vtkMRMLTractographyInteractiveSeedingNode);
 //----------------------------------------------------------------------------
 vtkMRMLTractographyInteractiveSeedingNode::vtkMRMLTractographyInteractiveSeedingNode()
 {
-   this->ThresholdMode = 0; //FA
+   this->ThresholdMode = vtkMRMLTractographyInteractiveSeedingNode::FractionalAnisotropy; //FA
    this->StartThreshold = 0.3;
    this->StoppingValue = 0.25;
    this->StoppingCurvature = 0.7;

--- a/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.cxx
+++ b/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.cxx
@@ -44,7 +44,7 @@ vtkMRMLTractographyInteractiveSeedingNode::vtkMRMLTractographyInteractiveSeeding
    this->SeedSelectedFiducials = 0;
    this->ROILabels = 0;
    this->RandomGrid = 0;
-   this->UseIndexSpace = 0;
+   this->UseIndexSpace = 1;
    this->SeedSpacing = 2.0;
    this->DisplayMode = 1;
    this->EnableSeeding = 1;

--- a/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.h
+++ b/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.h
@@ -61,6 +61,7 @@ public:
   // Get/Set Threshold Mode (module parameter)
   // 0 - FA
   // 1 - Linear Measure
+  enum { FractionalAnisotropy = 0, LinearMeasure = 1, PlanarMeasure = 2 };
   vtkGetMacro(ThresholdMode, int);
   vtkSetMacro(ThresholdMode, int);
 

--- a/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.h
+++ b/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.h
@@ -117,6 +117,7 @@ public:
   // Get/Set Display Mode (module parameter)
   // 0 - Lines
   // 1 - Tubes
+  enum { Lines = 0, Tubes = 1 };
   vtkGetMacro(DisplayMode, int);
   vtkSetMacro(DisplayMode, int);
 

--- a/Modules/Loadable/InteractiveSeeding/Logic/vtkSlicerTractographyInteractiveSeedingLogic.cxx
+++ b/Modules/Loadable/InteractiveSeeding/Logic/vtkSlicerTractographyInteractiveSeedingLogic.cxx
@@ -190,6 +190,25 @@ int vtkSlicerTractographyInteractiveSeedingLogic::IsObservedNode(vtkMRMLNode *no
 }
 
 //----------------------------------------------------------------------------
+// DRY local helper function
+void setStreamerThresholdMode(vtkSmartPointer<vtkHyperStreamlineDTMRI> streamer,
+                              int thresholdMode)
+{
+  if ( thresholdMode == vtkMRMLTractographyInteractiveSeedingNode::LinearMeasure )
+    {
+     streamer->SetThresholdModeToLinearMeasure();
+    }
+  else if ( thresholdMode == vtkMRMLTractographyInteractiveSeedingNode::FractionalAnisotropy )
+    {
+    streamer->SetThresholdModeToFractionalAnisotropy();
+    }
+  else if ( thresholdMode == vtkMRMLTractographyInteractiveSeedingNode::PlanarMeasure )
+    {
+    streamer->SetThresholdModeToPlanarMeasure();
+    }
+}
+
+//----------------------------------------------------------------------------
 void vtkSlicerTractographyInteractiveSeedingLogic::CreateTractsForOneSeed(vtkSeedTracts *seed,
                                                             vtkMRMLDiffusionTensorVolumeNode *volumeNode,
                                                             vtkMRMLTransformableNode *transformableNode,
@@ -282,18 +301,7 @@ void vtkSlicerTractographyInteractiveSeedingLogic::CreateTractsForOneSeed(vtkSee
   seed->SetVtkHyperStreamlinePointsSettings(streamer.GetPointer());
   seed->SetMinimumPathLength(minPathLength);
 
-  if ( thresholdMode == 0 )
-    {
-     streamer->SetThresholdModeToLinearMeasure();
-    }
-  else if ( thresholdMode == 1 )
-    {
-    streamer->SetThresholdModeToFractionalAnisotropy();
-    }
-  else if ( thresholdMode == 2 )
-    {
-    streamer->SetThresholdModeToPlanarMeasure();
-    }
+  setStreamerThresholdMode(streamer.GetPointer(), thresholdMode);
 
   //streamer->SetMaximumPropagationDistance(this->MaximumPropagationDistance);
   streamer->SetStoppingThreshold(stoppingValue);
@@ -754,7 +762,8 @@ int vtkSlicerTractographyInteractiveSeedingLogic::CreateTractsForLabelMap(
   else
     {
     math->SetInputConnection(volumeNode->GetImageDataConnection());
-    if ( thresholdMode == 0 )
+    if ( thresholdMode ==
+         vtkMRMLTractographyInteractiveSeedingNode::LinearMeasure )
       {
       math->SetOperationToLinearMeasure();
       }
@@ -910,18 +919,7 @@ int vtkSlicerTractographyInteractiveSeedingLogic::CreateTractsForLabelMap(
   vtkNew<vtkHyperStreamlineDTMRI> streamer;
   seed->SetVtkHyperStreamlinePointsSettings(streamer.GetPointer());
 
-  if ( thresholdMode == 0 )
-    {
-     streamer->SetThresholdModeToLinearMeasure();
-    }
-  else if ( thresholdMode == 1 )
-    {
-    streamer->SetThresholdModeToFractionalAnisotropy();
-    }
-  else if ( thresholdMode == 2 )
-    {
-    streamer->SetThresholdModeToPlanarMeasure();
-    }
+  setStreamerThresholdMode(streamer.GetPointer(), thresholdMode);
 
   streamer->SetStoppingThreshold(stoppingValue);
   streamer->SetMaximumPropagationDistance(maxPathLength);

--- a/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.cxx
+++ b/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.cxx
@@ -247,8 +247,8 @@ void qSlicerTractographyInteractiveSeedingModuleWidget::setup()
                 SLOT(setFiducialRegionStep(double)));
 
   QObject::connect(d->DisplayTracksComboBox,
-                SIGNAL(currentIndexChanged(int)),
-                SLOT(setTrackDisplayMode(int)));
+                SIGNAL(currentIndexChanged(const QString&)),
+                SLOT(setTrackDisplayMode(const QString&)));
 
   QObject::connect(d->SeedSelectedCheckBox,
                 SIGNAL(stateChanged(int)),
@@ -614,12 +614,22 @@ void qSlicerTractographyInteractiveSeedingModuleWidget::updateWidgetFromMRML()
     d->StoppingCurvatureSpinBox->setValue(paramNode->GetStoppingCurvature());
     d->StoppingCriteriaComboBox->setCurrentIndex(paramNode->GetThresholdMode());
     d->StoppingValueSpinBox->setValue(paramNode->GetStoppingValue());
-    d->DisplayTracksComboBox->setCurrentIndex(paramNode->GetDisplayMode());
     d->ROILabelInput->setText(paramNode->ROILabelsToString().c_str());
     d->RandomGridCheckBox->setChecked(paramNode->GetRandomGrid());
     d->UseIndexSpaceCheckBox->setChecked(paramNode->GetUseIndexSpace());
     d->StartThresholdSlider->setValue(paramNode->GetStartThreshold());
     d->SeedSpacingSlider->setValue(paramNode->GetSeedSpacing());
+
+    { // Use enums for display mode
+      QString target;
+      switch (paramNode->GetDisplayMode())
+        {
+        case vtkMRMLTractographyInteractiveSeedingNode::Tubes: target = "Tubes";
+        case vtkMRMLTractographyInteractiveSeedingNode::Lines: target = "Lines";
+        default: assert("Unknown display mode type!"); target = "Lines";
+        }
+      d->DisplayTracksComboBox->setCurrentIndex(d->DisplayTracksComboBox->findText(target));
+    }
 
     d->ParameterNodeSelector->setCurrentNode(
       this->mrmlScene()->GetNodeByID(paramNode->GetID()));
@@ -713,12 +723,17 @@ void qSlicerTractographyInteractiveSeedingModuleWidget::setStoppingCriteria(cons
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerTractographyInteractiveSeedingModuleWidget::setTrackDisplayMode(int value)
+void qSlicerTractographyInteractiveSeedingModuleWidget::setTrackDisplayMode(const QString& value)
 {
-  if (this->TractographyInteractiveSeedingNode)
-    {
-    this->TractographyInteractiveSeedingNode->SetDisplayMode(value);
-    }
+  if (NULL == this->TractographyInteractiveSeedingNode)
+    return;
+
+  if (value == "Lines")
+    this->TractographyInteractiveSeedingNode->SetDisplayMode(vtkMRMLTractographyInteractiveSeedingNode::Lines);
+  else if (value == "Tubes")
+    this->TractographyInteractiveSeedingNode->SetDisplayMode(vtkMRMLTractographyInteractiveSeedingNode::Tubes);
+  else
+    assert("Unhandled Track Display Mode");
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.cxx
+++ b/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.cxx
@@ -219,8 +219,8 @@ void qSlicerTractographyInteractiveSeedingModuleWidget::setup()
                 SLOT(setStoppingCurvature(double)));
 
   QObject::connect(d->StoppingCriteriaComboBox,
-                SIGNAL(currentIndexChanged(int)),
-                SLOT(setStoppingCriteria(int)));
+                SIGNAL(currentIndexChanged(const QString&)),
+                SLOT(setStoppingCriteria(const QString&)));
 
   QObject::connect(d->StoppingValueSpinBox,
                 SIGNAL(valueChanged(double)),
@@ -366,7 +366,8 @@ void qSlicerTractographyInteractiveSeedingModuleWidget::setParametersPreset(int 
     }
   if (index == 0) //Slicer4 Interctive Seeding Defaults
     {
-     this->TractographyInteractiveSeedingNode->SetThresholdMode(0); //FA
+     this->TractographyInteractiveSeedingNode->SetThresholdMode(
+             vtkMRMLTractographyInteractiveSeedingNode::FractionalAnisotropy); // FA
      this->TractographyInteractiveSeedingNode->SetStoppingValue(0.25);
      this->TractographyInteractiveSeedingNode->SetStoppingCurvature(0.7);
      this->TractographyInteractiveSeedingNode->SetIntegrationStep(0.5);
@@ -382,7 +383,8 @@ void qSlicerTractographyInteractiveSeedingModuleWidget::setParametersPreset(int 
     }
   else if (index == 1) //Slicer3 Fiducial Seeding Defaults
     {
-     this->TractographyInteractiveSeedingNode->SetThresholdMode(1); //LM
+     this->TractographyInteractiveSeedingNode->SetThresholdMode(
+             vtkMRMLTractographyInteractiveSeedingNode::LinearMeasure); //LM
      this->TractographyInteractiveSeedingNode->SetStoppingValue(0.25);
      this->TractographyInteractiveSeedingNode->SetStoppingCurvature(0.7);
      this->TractographyInteractiveSeedingNode->SetIntegrationStep(0.5);
@@ -398,7 +400,8 @@ void qSlicerTractographyInteractiveSeedingModuleWidget::setParametersPreset(int 
     }
   else if (index == 2) //Slicer3 Labelmap Seeding Defaults
     {
-     this->TractographyInteractiveSeedingNode->SetThresholdMode(1); // LM
+     this->TractographyInteractiveSeedingNode->SetThresholdMode(
+             vtkMRMLTractographyInteractiveSeedingNode::LinearMeasure); // LM
      this->TractographyInteractiveSeedingNode->SetStoppingValue(0.1);
      this->TractographyInteractiveSeedingNode->SetStoppingCurvature(0.8);
      this->TractographyInteractiveSeedingNode->SetIntegrationStep(0.5);
@@ -693,15 +696,22 @@ void qSlicerTractographyInteractiveSeedingModuleWidget::setFiducialRegionStep(do
     }
 }
 
-
 //-----------------------------------------------------------------------------
-void qSlicerTractographyInteractiveSeedingModuleWidget::setStoppingCriteria(int value)
+void qSlicerTractographyInteractiveSeedingModuleWidget::setStoppingCriteria(const QString& value)
 {
-  if (this->TractographyInteractiveSeedingNode)
-    {
-    this->TractographyInteractiveSeedingNode->SetThresholdMode(value);
-    }
+  if (NULL == this->TractographyInteractiveSeedingNode)
+    return;
+
+  if (value == "Fractional Anisotropy")
+    this->TractographyInteractiveSeedingNode->SetThresholdMode
+          (vtkMRMLTractographyInteractiveSeedingNode::FractionalAnisotropy);
+  else if (value == "Linear Measure")
+    this->TractographyInteractiveSeedingNode->SetThresholdMode
+          (vtkMRMLTractographyInteractiveSeedingNode::LinearMeasure);
+  else
+    assert("Unhandled Stopping Criteria");
 }
+
 //-----------------------------------------------------------------------------
 void qSlicerTractographyInteractiveSeedingModuleWidget::setTrackDisplayMode(int value)
 {

--- a/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.h
+++ b/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.h
@@ -79,7 +79,7 @@ public slots:
   void setFiberBundleNode(vtkMRMLNode *node);
 
   /// Set stopping criteria 0-Linear Measure, 1 - FA
-  void setStoppingCriteria(int value);
+  void setStoppingCriteria(const QString&);
 
   /// Set display mode 0-line 1-tube
   void setTrackDisplayMode(int value);

--- a/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.h
+++ b/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.h
@@ -82,7 +82,7 @@ public slots:
   void setStoppingCriteria(const QString&);
 
   /// Set display mode 0-line 1-tube
-  void setTrackDisplayMode(int value);
+  void setTrackDisplayMode(const QString&);
 
   /// Set stopping curvature
   void setStoppingCurvature(double value);


### PR DESCRIPTION
- 813704e fixes a UI bug, see the commit message for 415a5f1 for explanation.
- bb8d1a3, 978a147, and efa22a0 re-apply missing/reverted commits from #65 and #66.