### PR TITLE
BUG: fix color-by-tensorproperty after by-orientation

### DIFF
--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleTubeDisplayNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleTubeDisplayNode.cxx
@@ -218,6 +218,7 @@ void vtkMRMLFiberBundleTubeDisplayNode::UpdateAssignedAttribute()
   else if ((this->GetColorMode ( ) == vtkMRMLFiberBundleDisplayNode::colorModeScalar) &&
            (DiffusionTensorDisplayPropertiesNode != NULL))
     {
+    this->TensorToColor->SetColorModeToEigenvalues();
     this->TensorToColor->SetExtractScalar(1);
 
     switch ( DiffusionTensorDisplayPropertiesNode->GetColorGlyphBy( ))


### PR DESCRIPTION
Old bug (at least Slicer 4.5) I noticed fixing #87: 
- select orientation color modes
- return to color-by-tensor property
- model will be solid color only, until the selected invariant is changed.

Reason is:

This flag is reset when the pipeline is changed, so must be set again when re-enabling the
TensorToColor filter. Otherwise the model will appear solid until the selected invariant is
changed -- which triggers resetting this flag internally (but only on the expensive path if
selected invariant is actually changed).