### PR TITLE
WIP: refactor vtkMRMLFiberBundleNode (2/2)

### DIFF
--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleDisplayNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleDisplayNode.cxx
@@ -217,7 +217,7 @@ void vtkMRMLFiberBundleDisplayNode::SetAndObserveDiffusionTensorDisplayPropertie
   //so we emit the event that the polydata has been modified
   if (cnode)
     {
-    this->InvokeEvent(vtkMRMLModelNode::PolyDataModifiedEvent, this);
+    this->InvokeEvent(vtkMRMLModelNode::MeshModifiedEvent, this);
     }
 }
 

--- a/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.cxx
@@ -417,8 +417,8 @@ void vtkMRMLTractographyDisplayDisplayableManager::SetMRMLSceneInternal(vtkMRMLS
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLTractographyDisplayDisplayableManager
-::ProcessMRMLNodesEvents(vtkObject *caller, unsigned long event, void * vtkNotUsed(callData))
+void vtkMRMLTractographyDisplayDisplayableManager::ProcessMRMLNodesEvents
+       (vtkObject *caller, unsigned long event, void * vtkNotUsed(callData))
 {
 
   vtkMRMLInteractionNode * interactionNode = vtkMRMLInteractionNode::SafeDownCast(caller);

--- a/Modules/Loadable/TractographyDisplay/Widgets/Resources/UI/qSlicerTractographyEditorROIWidget.ui
+++ b/Modules/Loadable/TractographyDisplay/Widgets/Resources/UI/qSlicerTractographyEditorROIWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>410</width>
-    <height>172</height>
+    <height>232</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -40,9 +40,6 @@
      <property name="showHidden">
       <bool>true</bool>
      </property>
-     <property name="selectNodeUponCreation">
-      <bool>true</bool>
-     </property>
      <property name="noneEnabled">
       <bool>true</bool>
      </property>
@@ -50,6 +47,9 @@
       <bool>true</bool>
      </property>
      <property name="renameEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="selectNodeUponCreation">
       <bool>true</bool>
      </property>
     </widget>
@@ -85,14 +85,14 @@
     </widget>
    </item>
    <item row="2" column="0">
-     <widget class="QCheckBox" name="InteractiveROI">
-       <property name="text">
-         <string>Interactive ROI</string>
-       </property>
-       <property name="checked">
-         <bool>true</bool>
-       </property>
-     </widget>
+    <widget class="QCheckBox" name="InteractiveROI">
+     <property name="text">
+      <string>Interactive ROI Updates</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item row="2" column="1">
     <widget class="QCheckBox" name="ROIVisibility">
@@ -140,9 +140,6 @@ QCheckBox::indicator:unchecked {
      <property name="showHidden">
       <bool>true</bool>
      </property>
-     <property name="selectNodeUponCreation">
-      <bool>true</bool>
-     </property>
      <property name="noneEnabled">
       <bool>true</bool>
      </property>
@@ -150,6 +147,9 @@ QCheckBox::indicator:unchecked {
       <bool>true</bool>
      </property>
      <property name="renameEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="selectNodeUponCreation">
       <bool>true</bool>
      </property>
     </widget>
@@ -170,17 +170,24 @@ QCheckBox::indicator:unchecked {
       <string>Confirm update</string>
      </property>
      <property name="checked">
-       <bool>true</bool>
+      <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QCheckBox" name="EnableFiberEdit">
      <property name="text">
       <string>Enable Interactive Edit</string>
      </property>
      <property name="checked">
-       <bool>false</bool>
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayWidget.cxx
@@ -282,6 +282,7 @@ void qSlicerTractographyDisplayWidget::setVisibility(bool state)
     {
     return;
     }
+
   d->FiberBundleDisplayNode->SetVisibility(state);
 }
 
@@ -362,10 +363,7 @@ void qSlicerTractographyDisplayWidget::setColorByScalar()
 void qSlicerTractographyDisplayWidget::onColorByScalarChanged(int scalarIndex)
 {
   Q_D(qSlicerTractographyDisplayWidget);
-  if (
-      !d->FiberBundleDisplayNode || !d->FiberBundleNode ||
-      !d->FiberBundleNode->GetPolyData() || !d->FiberBundleNode->GetPolyData()->GetPointData()
-      )
+  if (!d->FiberBundleDisplayNode || !d->FiberBundleNode)
     {
     return;
     }

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.cxx
@@ -176,15 +176,15 @@ void qSlicerTractographyEditorROIWidget::
       d->AnnotationMRMLNodeForFiberSelection = d->FiberBundleNode->GetAnnotationNode();
       d->ROIForFiberSelectionMRMLNodeSelector->setCurrentNode(d->AnnotationMRMLNodeForFiberSelection);
     }
-    if (!d->FiberBundleNode->GetSelectWithAnnotationNode())
+    if (!d->FiberBundleNode->GetSelectWithAnnotation())
     {
       d->DisableROI->setChecked(true);
     }
-    else if (d->FiberBundleNode->GetSelectionWithAnnotationNodeMode() == vtkMRMLFiberBundleNode::PositiveAnnotationNodeSelection)
+    else if (d->FiberBundleNode->GetAnnotationSelectionMode() == vtkMRMLFiberBundleNode::PositiveSelection)
     {
       d->PositiveROI->setChecked(true);
     }
-    else if (d->FiberBundleNode->GetSelectionWithAnnotationNodeMode() == vtkMRMLFiberBundleNode::NegativeAnnotationNodeSelection)
+    else if (d->FiberBundleNode->GetAnnotationSelectionMode() == vtkMRMLFiberBundleNode::NegativeSelection)
     {
       d->NegativeROI->setChecked(true);
     }
@@ -219,6 +219,10 @@ void qSlicerTractographyEditorROIWidget::setAnnotationMRMLNodeForFiberSelection(
       {
       d->AnnotationMRMLNodeForFiberSelection = AnnotationNode;
       d->FiberBundleNode->SetAndObserveAnnotationNodeID(d->AnnotationMRMLNodeForFiberSelection->GetID());
+      }
+    else
+      {
+      d->FiberBundleNode->SetAndObserveAnnotationNodeID(NULL); // TODO nullptr
       }
     this->updateWidgetFromMRML();
   }
@@ -308,7 +312,7 @@ void qSlicerTractographyEditorROIWidget::disableROISelection(bool arg)
     Q_D(qSlicerTractographyEditorROIWidget);
     if (d->FiberBundleNode && d->AnnotationMRMLNodeForFiberSelection)
     {
-      d->FiberBundleNode->SelectWithAnnotationNodeOff();
+      d->FiberBundleNode->SetSelectWithAnnotation(false);
     }
   }
 }
@@ -320,8 +324,8 @@ void qSlicerTractographyEditorROIWidget::positiveROISelection(bool arg)
     Q_D(qSlicerTractographyEditorROIWidget);
     if (d->FiberBundleNode && d->AnnotationMRMLNodeForFiberSelection)
     {
-      d->FiberBundleNode->SelectWithAnnotationNodeOn();
-      d->FiberBundleNode->SetSelectionWithAnnotationNodeModeToPositive();
+      d->FiberBundleNode->SetSelectWithAnnotation(true);
+      d->FiberBundleNode->SetAnnotationSelectionMode(vtkMRMLFiberBundleNode::PositiveSelection);
     }
   }
 }
@@ -333,8 +337,8 @@ void qSlicerTractographyEditorROIWidget::negativeROISelection(bool arg)
     Q_D(qSlicerTractographyEditorROIWidget);
     if (d->FiberBundleNode && d->AnnotationMRMLNodeForFiberSelection)
     {
-      d->FiberBundleNode->SelectWithAnnotationNodeOn();
-      d->FiberBundleNode->SetSelectionWithAnnotationNodeModeToNegative();
+      d->FiberBundleNode->SetSelectWithAnnotation(true);
+      d->FiberBundleNode->SetAnnotationSelectionMode(vtkMRMLFiberBundleNode::NegativeSelection);
     }
   }
 }


### PR DESCRIPTION
Fixes interactive sub-sampling and continuous ROI selection.
Fixes de-selecting ROI node.
Improves performance by hiding filter output behind passthrough.
Cleans up cruft.

- [x] re-fix single-shot extract-from-ROI
- [x] rename `Interactive ROI` to  `Interactive ROI Update`
- [x] fix interactive sub-sampling