### PR TITLE
BUG: fix crash in FB2LabelMap due to mismatched NumPy/VTK dtype size

### DIFF
--- a/Modules/Scripted/FiberBundleToLabelMap/FiberBundleToLabelMap.py
+++ b/Modules/Scripted/FiberBundleToLabelMap/FiberBundleToLabelMap.py
@@ -196,7 +196,8 @@ class FiberBundleToLabelMapLogic:
     for startCellId in xrange(0, cellCount, CELLS_TO_PROCESS):
       # generate list of cell Ids to sample
       cellIdsAr = numpy.arange(startCellId,
-                               min(cellCount, startCellId + CELLS_TO_PROCESS))
+                               min(cellCount, startCellId + CELLS_TO_PROCESS),
+                               dtype=vtk.util.numpy_support.ID_TYPE_CODE)
       cellIds.SetVoidArray(cellIdsAr, cellIdsAr.size, 1)
 
       # update the selection node to extract those cells


### PR DESCRIPTION
NumPy defaults to 'long' on Windows, which is int32. Use a helper inside VTK which has the correct dtype for vtkIdTypeArray.