### PR TITLE
BUG: fix Tractography Display 'Interactive Edit' feature

### DIFF
--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
@@ -348,12 +348,10 @@ vtkMRMLFiberBundleDisplayNode* vtkMRMLFiberBundleNode::GetGlyphDisplayNode()
 void vtkMRMLFiberBundleNode::SetMeshToDisplayNode(vtkMRMLModelDisplayNode *modelDisplayNode)
 {
   // overload here to make sure the display node gets our filtered output.
-
-  // TODO: this override is stupid. Logically, if anything, a DisplayableNode pipeline
-  // should form a daisy chain with output from the parent class. However, vtkMRMLModelNode
-  // uses its internal MeshConnection object directly, so here we are.
+  // TODO: vtkMRMLModelNode uses the internally stored connection... change?
 
   assert(modelDisplayNode);
+  this->ExtractSubsample->SetInputConnection(this->MeshConnection);
   modelDisplayNode->SetInputMeshConnection(this->GetFilteredMeshConnection());
 }
 
@@ -389,7 +387,6 @@ void fixupPolyDataTensors(vtkAlgorithmOutput* inputPort) {
 void vtkMRMLFiberBundleNode::SetMeshConnection(vtkAlgorithmOutput *inputPort)
 {
   this->Superclass::SetMeshConnection(inputPort);
-
   this->ExtractSubsample->SetInputConnection(inputPort);
 
   fixupPolyDataTensors(inputPort);
@@ -419,7 +416,6 @@ void vtkMRMLFiberBundleNode::SetMeshConnection(vtkAlgorithmOutput *inputPort)
       {
       this->UpdateROISelection();
       }
-
     }
 }
 
@@ -549,7 +545,7 @@ void vtkMRMLFiberBundleNode::UpdateSubsampling()
     }
 
   const vtkIdType numberOfFibers = polyData->GetNumberOfLines();
-  if (this->ShuffledIds->GetNumberOfTuples() < numberOfFibers)
+  if (this->ShuffledIds->GetNumberOfTuples() != numberOfFibers)
     {
 
     std::vector<vtkIdType> idVector;

--- a/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.cxx
@@ -292,31 +292,27 @@ void vtkMRMLTractographyDisplayDisplayableManager::DeletePickedFibers(vtkMRMLFib
     return;
   }
 
-  int shuffleIDs = fiberBundleNode->GetEnableShuffleIDs();
-  fiberBundleNode->SetEnableShuffleIDs(0);
-
   vtkPolyData *polyData = vtkPolyData::New();
   polyData->DeepCopy(fiberBundleNode->GetPolyData());
   for (unsigned int i=0; i<cellIDs.size(); i++)
     {
     if (cellIDs[i] >= 0)
       {
+      vtkIdType cellID = fiberBundleNode->GetUnShuffledFiberID(cellIDs[i]);
       polyData->DeleteCell(cellIDs[i]);
       }
     }
   polyData->RemoveDeletedCells();
   fiberBundleNode->SetAndObservePolyData(polyData);
   polyData->Delete();
-
-  fiberBundleNode->SetEnableShuffleIDs(shuffleIDs);
-
 }
 
 //---------------------------------------------------------------------------
 void vtkMRMLTractographyDisplayDisplayableManager::SelectPickedFibers(vtkMRMLFiberBundleNode *fiberBundleNode,
                                                                      std::vector<vtkIdType> &cellIDs)
 {
-  if (!fiberBundleNode)
+  if ((!fiberBundleNode) ||
+      (!fiberBundleNode->GetPolyData()))
     {
     return;
     }

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.cxx
@@ -120,7 +120,7 @@ void qSlicerTractographyDisplayModuleWidget::setFiberBundleNode(vtkMRMLFiberBund
 {
   Q_D(qSlicerTractographyDisplayModuleWidget);
 
-  if (fiberBundleNode == 0)
+  if (fiberBundleNode == nullptr)
     {
     d->TractDisplayModesTabWidget->setEnabled(false);
     d->ROIEditorWidget->setEnabled(false);

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.cxx
@@ -122,7 +122,7 @@ void qSlicerTractographyEditorROIWidget::
 
   d->FiberBundleNode = fiberBundleNode;
 
-  if (fiberBundleNode && fiberBundleNode->GetNumberOfDisplayNodes() > 1)
+  if (fiberBundleNode && fiberBundleNode->GetNumberOfDisplayNodes() > 0)
   {
     d->AnnotationMRMLNodeForFiberSelection = fiberBundleNode->GetAnnotationNode();
     d->ROIForFiberSelectionMRMLNodeSelector->setCurrentNode(d->AnnotationMRMLNodeForFiberSelection);
@@ -137,9 +137,9 @@ void qSlicerTractographyEditorROIWidget::
 {
   Q_D(qSlicerTractographyEditorROIWidget);
 
+  // make edit widgets active/inactive based on node selection
   if ( !d->FiberBundleNode || !d->AnnotationMRMLNodeForFiberSelection)
   {
-    // make widgest inactive
     d->ConfirmFiberBundleUpdate->setEnabled(false);
     d->CreateNewFiberBundle->setEnabled(false);
     d->DisableROI->setEnabled(false);
@@ -152,7 +152,6 @@ void qSlicerTractographyEditorROIWidget::
   }
   else
   {
-    // make widgest active
     d->ConfirmFiberBundleUpdate->setEnabled(true);
     d->CreateNewFiberBundle->setEnabled(true);
     d->DisableROI->setEnabled(true);
@@ -162,14 +161,23 @@ void qSlicerTractographyEditorROIWidget::
     d->PositiveROI->setEnabled(true);
     d->ROIVisibility->setEnabled(true);
     d->UpdateBundleFromSelection->setEnabled(true);
+    d->EnableFiberEdit->setEnabled(true);
   }
 
-  if ( !d->FiberBundleNode )
+  if (!d->FiberBundleNode)
     {
+    // turn off editing if there is no selection
+    this->setInteractiveFiberEdit(false);
+    d->EnableFiberEdit->setEnabled(false);
+
     return;
     }
+  else
+    {
+    d->EnableFiberEdit->setEnabled(true);
+    }
 
-  if (d->FiberBundleNode->GetNumberOfDisplayNodes() > 1)
+  if (d->FiberBundleNode->GetNumberOfDisplayNodes() > 0)
   {
     if (d->AnnotationMRMLNodeForFiberSelection != d->FiberBundleNode->GetAnnotationNode())
     {


### PR DESCRIPTION
Partially fixes the Interactive Edit feature. There is a remaining issue: activating the edit tool requires clicking in the render window after `Enable Interactive Edit` is checked. I think this is a state issue in the interactor node, but I'm not sure how to fix that yet.

also note that, as per a comment in the code, the 's' (select) feature currently only works with color-by-scalar mode.