### PR TITLE
BUG: Replace saferef with weakref

### DIFF
--- a/Modules/Scripted/DICOM2FullBrainTractography/DICOM2FullBrainTractographyLib/workflow_support.py
+++ b/Modules/Scripted/DICOM2FullBrainTractography/DICOM2FullBrainTractographyLib/workflow_support.py
@@ -5,7 +5,7 @@ import vtk
 import ctk
 import qt
 
-import saferef
+import weakref
 import slicer
 
 __all__ = ['Workflow', 'GeneralizedStep', 'display_error']
@@ -132,13 +132,13 @@ class GeneralizedStep(ctk.ctkWorkflowWidgetStep, ) :
         self.qt_widget = qt_widget
 
         if onEntryCallback:
-            self.weak_onEntryCallback = saferef.safeRef(onEntryCallback)
+            self.weak_onEntryCallback = weakref.WeakMethod(onEntryCallback)
 
         if validateCallback:
-            self.weak_validateCallback = saferef.safeRef(validateCallback)
+            self.weak_validateCallback = weakref.WeakMethod(validateCallback)
 
         if onExitCallback:
-            self.weak_onExitCallback = saferef.safeRef(onExitCallback)
+            self.weak_onExitCallback = weakref.WeakMethod(onExitCallback)
 
     def createUserInterface(self):
         layout = qt.QVBoxLayout(self)


### PR DESCRIPTION
This aims to solve various [failing](http://slicer.cdash.org/testDetails.php?test=9642248&build=1608020) test cases for Slicer-Preview (aka nightly). 

The saferef module was removed from Slicer in https://github.com/Slicer/Slicer/commit/eb4570e90ed533228c4c68aa950e72a43258eb27.  

> Starting with Python 3.4, the weakref module available in python is improved to provide the 'weakref.WeakMethod' class.