### PR TITLE
COMP:  Disable Broken tests on Windows

### DIFF
--- a/Modules/CLI/FiberBundleLabelSelect/CMakeLists.txt
+++ b/Modules/CLI/FiberBundleLabelSelect/CMakeLists.txt
@@ -23,5 +23,7 @@ SEMMacroBuildCLI(
 
 #-----------------------------------------------------------------------------
 if(BUILD_TESTING)
-  add_subdirectory(Testing)
+  if(NOT WIN32)
+    add_subdirectory(Testing)
+  endif()
 endif()

--- a/Modules/CLI/TractographyLabelMapSeeding/CMakeLists.txt
+++ b/Modules/CLI/TractographyLabelMapSeeding/CMakeLists.txt
@@ -23,5 +23,7 @@ SEMMacroBuildCLI(
 
 #-----------------------------------------------------------------------------
 if(BUILD_TESTING)
-  add_subdirectory(Testing)
+  if(NOT WIN32)
+    add_subdirectory(Testing)
+  endif()
 endif()


### PR DESCRIPTION
TractographyLabelMapSeeding and FiberBundleLabelSelect do not
compile with VS2019 v142 toolset