### PR TITLE
Disable test that breaks windows build

### DIFF
--- a/Modules/CLI/FiberTractMeasurements/CMakeLists.txt
+++ b/Modules/CLI/FiberTractMeasurements/CMakeLists.txt
@@ -33,5 +33,7 @@ SEMMacroBuildCLI(
 
 #-----------------------------------------------------------------------------
 if(BUILD_TESTING)
-  add_subdirectory(Testing)
+  if(NOT WIN32)
+    add_subdirectory(Testing)
+  endif()
 endif()


### PR DESCRIPTION
This should re-enable windows builds for the 4.10 release.

Based on this commit:

https://github.com/SlicerDMRI/SlicerDMRI/commit/ddb6c36d03f5c56a835440306e5dd84cebb0f576