### PR TITLE
BUG: explicitly flag all vtk fiber bundles RAS

### DIFF
--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
@@ -608,6 +608,15 @@ vtkMRMLStorageNode* vtkMRMLFiberBundleNode::CreateDefaultStorageNode()
 }
 
 //---------------------------------------------------------------------------
+std::string vtkMRMLFiberBundleNode:: GetDefaultStorageNodeClassName(const char* filename /* =nullptr */)
+{
+  vtkDebugMacro("vtkMRMLFiberBundleNode::GetDefaultStorageNodeClassName");
+  return "vtkMRMLFiberBundleStorageNode";
+}
+
+
+
+//---------------------------------------------------------------------------
 vtkMRMLFiberBundleDisplayNode* addDisplayNodeAndDTDPN(vtkMRMLFiberBundleNode* fbNode,
                                                       vtkMRMLFiberBundleDisplayNode* node)
 {

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
@@ -161,6 +161,8 @@ public:
   /// Create and return default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode() VTK_OVERRIDE;
 
+  std::string GetDefaultStorageNodeClassName(const char* filename /* =nullptr */) override;
+
   /// Create default display nodes
   virtual void CreateDefaultDisplayNodes() VTK_OVERRIDE;
 

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleStorageNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleStorageNode.cxx
@@ -25,6 +25,7 @@ vtkMRMLNodeNewMacro(vtkMRMLFiberBundleStorageNode);
 vtkMRMLFiberBundleStorageNode::vtkMRMLFiberBundleStorageNode()
 {
   this->DefaultWriteFileExtension = "vtk";
+  this->CoordinateSystem = vtkMRMLStorageNode::CoordinateSystemRAS;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
During the 4.11 development process the convention
was introduced that all storage nodes would try to
be aware of the coordinate system conventions and
read/write them in files explicitly where possible.
See [1].

For data files that do not explicitly declare their
coordinate system, such as STL files for 3D printing,
it was decided that LPS was the most convention so so files
that don't declare a convention are treated as LPS.

The problem for SlicerDMRI is that the community has
many terabytes of .vtk and .vtp fiber bundle files that do
not declare that they are in RAS, so they the new convention
reads them as LPS.  These old files would not be
read properly even if newly written files were saved
with explicit coordinate system.

This fix allows existing fiber bundles to be loaded
and also carries forward the convention that fiber
bundles in vtk/vtp format are in RAS coordinates.

With this fix .vtk files such as those generated by
ukftractography or other pipelines will be correctly
read as RAS.

With this fix fiber bundle files saved from Slicer
will be flagged as RAS so they will read correctly
even if loaded as models instead of fiber bundles.


[1] https://github.com/Slicer/Slicer/commit/6036edbc4b67712822ccb4ee89139cab1cbce3f2

Fixes #136