### PR TITLE
Fix trk crash

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.cxx
+++ b/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.cxx
@@ -136,6 +136,7 @@ vtkMRMLFiberBundleNode* vtkSlicerFiberBundleLogic::AddFiberBundle (const char* f
   else
     {
     vtkErrorMacro("Couldn't read file, returning null fiberBundle node: " << filename);
+    fiberBundleNode = nullptr;
     }
 
   return fiberBundleNode;

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
@@ -608,6 +608,15 @@ vtkMRMLStorageNode* vtkMRMLFiberBundleNode::CreateDefaultStorageNode()
 }
 
 //---------------------------------------------------------------------------
+std::string vtkMRMLFiberBundleNode:: GetDefaultStorageNodeClassName(const char* filename /* =nullptr */)
+{
+  vtkDebugMacro("vtkMRMLFiberBundleNode::GetDefaultStorageNodeClassName");
+  return "vtkMRMLFiberBundleStorageNode";
+}
+
+
+
+//---------------------------------------------------------------------------
 vtkMRMLFiberBundleDisplayNode* addDisplayNodeAndDTDPN(vtkMRMLFiberBundleNode* fbNode,
                                                       vtkMRMLFiberBundleDisplayNode* node)
 {

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
@@ -161,6 +161,8 @@ public:
   /// Create and return default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode() VTK_OVERRIDE;
 
+  std::string GetDefaultStorageNodeClassName(const char* filename /* =nullptr */) override;
+
   /// Create default display nodes
   virtual void CreateDefaultDisplayNodes() VTK_OVERRIDE;
 

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleStorageNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleStorageNode.cxx
@@ -25,6 +25,7 @@ vtkMRMLNodeNewMacro(vtkMRMLFiberBundleStorageNode);
 vtkMRMLFiberBundleStorageNode::vtkMRMLFiberBundleStorageNode()
 {
   this->DefaultWriteFileExtension = "vtk";
+  this->CoordinateSystem = vtkMRMLStorageNode::CoordinateSystemRAS;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION

    BUG: fix crash trying to load trk file
    
    This function probably used to use raw pointers
    and would have returned null if the file could
    not be read, but the smart pointer is not null,
    so it led to a crash.  Here we explicitly set
    the smart pointer to nullptr so it will go away.
    
    The crash would occur when trying to load a .trk
    file which could not be loaded.
