### PR TITLE
BUG: fix crash trying to load trk file

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.cxx
+++ b/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.cxx
@@ -136,6 +136,7 @@ vtkMRMLFiberBundleNode* vtkSlicerFiberBundleLogic::AddFiberBundle (const char* f
   else
     {
     vtkErrorMacro("Couldn't read file, returning null fiberBundle node: " << filename);
+    fiberBundleNode = nullptr;
     }
 
   return fiberBundleNode;


### PR DESCRIPTION
This function probably used to use raw pointers
and would have returned null if the file could
not be read, but the smart pointer is not null,
so it led to a crash.  Here we explicitly set
the smart pointer to nullptr so it will go away.

The crash would occur when trying to load a .trk
file which could not be loaded.