### PR TITLE
COMP: Add support for building against VTK 8.2.0 or 9.0.0

### DIFF
--- a/Libs/vtkDMRI/CMakeLists.txt
+++ b/Libs/vtkDMRI/CMakeLists.txt
@@ -122,13 +122,23 @@ if(VTK_WRAP_PYTHON)
     )
 
   # Set python module logic output
-  set_target_properties(${lib_name}Python ${lib_name}PythonD PROPERTIES
+  set_target_properties(${lib_name}Python PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_BIN_DIR}"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
     )
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    set_target_properties(${lib_name}Python PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_BIN_DIR}"
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
+      )
+  endif()
   # Export target
-  export(TARGETS ${lib_name}Python ${lib_name}PythonD APPEND FILE ${${lib_name}_EXPORT_FILE})
+  export(TARGETS ${lib_name}Python APPEND FILE ${${lib_name}_EXPORT_FILE})
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    export(TARGETS ${lib_name}PythonD APPEND FILE ${${lib_name}_EXPORT_FILE})
+  endif()
 endif()
 
 # --------------------------------------------------------------------------

--- a/Libs/vtkDMRI/vtkBSplineInterpolateImageFunction.h
+++ b/Libs/vtkDMRI/vtkBSplineInterpolateImageFunction.h
@@ -40,12 +40,12 @@ class  vtkDMRI_EXPORT vtkBSplineInterpolateImageFunction : public vtkImplicitFun
  public:
   static vtkBSplineInterpolateImageFunction *New();
   vtkTypeMacro(vtkBSplineInterpolateImageFunction, vtkImplicitFunction );
-  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  virtual void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  virtual double EvaluateFunction (double x[ImageDimension]) VTK_OVERRIDE;
+  virtual double EvaluateFunction (double x[ImageDimension]) override;
 
   virtual void EvaluateGradient (double x[ImageDimension],
-                                 double g[ImageDimension]) VTK_OVERRIDE;
+                                 double g[ImageDimension]) override;
   void SetInput(vtkImageData* dataset);
 
   unsigned int GetSplineOrder() { return this->SplineOrder; }

--- a/Libs/vtkDMRI/vtkHyperStreamlineDTMRI.h
+++ b/Libs/vtkDMRI/vtkHyperStreamlineDTMRI.h
@@ -47,7 +47,7 @@ class vtkDMRI_EXPORT vtkHyperStreamlineDTMRI : public vtkHyperStreamline
 {
 public:
   vtkTypeMacro(vtkHyperStreamlineDTMRI,vtkHyperStreamline);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   ///
   /// Construct object with initial starting position (0,0,0); integration
@@ -65,8 +65,8 @@ public:
 
   ///
   /// This is in mm, unlike superclass value which is a fraction of a cell.
-  /// Implement here instead of vtkSetMacro to use VTK_OVERRIDE
-  void SetIntegrationStepLength(double length) VTK_OVERRIDE {
+  /// Implement here instead of vtkSetMacro to use override
+  void SetIntegrationStepLength(double length) override {
     if (this->IntegrationStepLength != length) {
       this->IntegrationStepLength = length;
       this->Modified();
@@ -112,7 +112,7 @@ protected:
   ~vtkHyperStreamlineDTMRI();
 
   /// Integrate data
-  virtual int RequestData(vtkInformation *,vtkInformationVector**, vtkInformationVector *) VTK_OVERRIDE;
+  virtual int RequestData(vtkInformation *,vtkInformationVector**, vtkInformationVector *) override;
   void BuildLines(vtkDataSet *input, vtkPolyData *output);
   void BuildLinesForSingleTrajectory(vtkDataSet *input, vtkPolyData *output);
   void BuildLinesForTwoTrajectories(vtkDataSet *input, vtkPolyData *output);

--- a/Libs/vtkDMRI/vtkHyperStreamlineTeem.h
+++ b/Libs/vtkDMRI/vtkHyperStreamlineTeem.h
@@ -21,7 +21,7 @@ class vtkDMRI_EXPORT vtkHyperStreamlineTeem : public vtkHyperStreamlineDTMRI
 
  public:
   vtkTypeMacro(vtkHyperStreamlineTeem,vtkHyperStreamlineDTMRI);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   static vtkHyperStreamlineTeem *New();
 
@@ -29,7 +29,7 @@ class vtkDMRI_EXPORT vtkHyperStreamlineTeem : public vtkHyperStreamlineDTMRI
   vtkHyperStreamlineTeem();
   ~vtkHyperStreamlineTeem();
 
-  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE;
+  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
   void StartFiberFrom( const double position[3], tenFiberContext *fibercontext );
   void VisualizeFibers( const Nrrd *fibers );
 

--- a/Libs/vtkDMRI/vtkPolyDataColorLinesByOrientation.h
+++ b/Libs/vtkDMRI/vtkPolyDataColorLinesByOrientation.h
@@ -25,7 +25,7 @@ class vtkDMRI_EXPORT vtkPolyDataColorLinesByOrientation : public vtkPolyDataAlgo
 public:
   static vtkPolyDataColorLinesByOrientation *New();
   vtkTypeMacro(vtkPolyDataColorLinesByOrientation,vtkPolyDataAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   ///
   /// Turn on/off extraction of scalars for color.
@@ -65,9 +65,9 @@ protected:
   ~vtkPolyDataColorLinesByOrientation();
 
   /// Usual data generation method
-  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE;
+  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
-  virtual int FillInputPortInformation(int port, vtkInformation *info) VTK_OVERRIDE;
+  virtual int FillInputPortInformation(int port, vtkInformation *info) override;
 
   char* ScalarArrayName;
   int CopyOriginalData;

--- a/Libs/vtkDMRI/vtkPolyDataTensorToColor.h
+++ b/Libs/vtkDMRI/vtkPolyDataTensorToColor.h
@@ -28,7 +28,7 @@ class vtkDMRI_EXPORT vtkPolyDataTensorToColor : public vtkPolyDataAlgorithm
 public:
   static vtkPolyDataTensorToColor *New();
   vtkTypeMacro(vtkPolyDataTensorToColor,vtkPolyDataAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   vtkSetClampMacro(ColorMode, int, vtkTensorGlyph::COLOR_BY_SCALARS, vtkTensorGlyph::COLOR_BY_EIGENVALUES);
   vtkGetMacro(ColorMode, int);
@@ -72,9 +72,9 @@ protected:
   ~vtkPolyDataTensorToColor() {};
 
   /// Usual data generation method
-  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE;
+  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
-  virtual int FillInputPortInformation(int port, vtkInformation *info) VTK_OVERRIDE;
+  virtual int FillInputPortInformation(int port, vtkInformation *info) override;
 
   void ColorGlyphsBy(int measure);
   int ColorMode; /// The coloring mode to use for the glyphs.

--- a/Libs/vtkDMRI/vtkPreciseHyperStreamline.h
+++ b/Libs/vtkDMRI/vtkPreciseHyperStreamline.h
@@ -65,7 +65,7 @@ class vtkDMRI_EXPORT vtkPreciseHyperStreamline : public vtkPolyDataAlgorithm
 {
  public:
   vtkTypeMacro(vtkPreciseHyperStreamline,vtkPolyDataAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   ///
   /// Construct object with initial starting position (0,0,0); integration
@@ -258,7 +258,7 @@ class vtkDMRI_EXPORT vtkPreciseHyperStreamline : public vtkPolyDataAlgorithm
   ~vtkPreciseHyperStreamline();
 
   /// Integrate data
-  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE;
+  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
   void BuildTube();
 
   /// Flag indicates where streamlines start from (either position or location)

--- a/Libs/vtkDMRI/vtkPreciseHyperStreamlinePoints.h
+++ b/Libs/vtkDMRI/vtkPreciseHyperStreamlinePoints.h
@@ -27,7 +27,7 @@ class vtkDMRI_EXPORT vtkPreciseHyperStreamlinePoints : public vtkPreciseHyperStr
 public:
   static vtkPreciseHyperStreamlinePoints *New();
   vtkTypeMacro(vtkPreciseHyperStreamlinePoints,vtkPolyDataAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   vtkGetObjectMacro(PreciseHyperStreamline0,vtkPoints);
   vtkGetObjectMacro(PreciseHyperStreamline1,vtkPoints);
@@ -36,7 +36,7 @@ protected:
   vtkPreciseHyperStreamlinePoints();
   ~vtkPreciseHyperStreamlinePoints();
 
-  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE;
+  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
   /// convenient pointers to PreciseHyperStreamline1 and PreciseHyperStreamline2
   vtkPoints *PreciseHyperStreamlines[2];

--- a/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.h
+++ b/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.h
@@ -171,17 +171,17 @@ class vtkDMRI_EXPORT vtkTeemEstimateDiffusionTensor : public vtkThreadedImageAlg
   ///
   int NumberOfWLSIterations;
 
-  virtual int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE;
+  virtual int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
   void ThreadedExecute(vtkImageData *inData, vtkImageData *outData,
-        int extent[6], int id) VTK_OVERRIDE;
+        int extent[6], int id) override;
 
   /// We override this in order to allocate output tensors
   /// before threading happens.  This replaces the superclass
   /// vtkImageAlgorithm's RequestData function.
   virtual int RequestData(vtkInformation* request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector) VTK_OVERRIDE;
+                          vtkInformationVector* outputVector) override;
 };
 
 #endif

--- a/Libs/vtkDMRI/vtkTensorImplicitFunctionToFunctionSet.h
+++ b/Libs/vtkDMRI/vtkTensorImplicitFunctionToFunctionSet.h
@@ -31,8 +31,8 @@ class vtkDMRI_EXPORT vtkTensorImplicitFunctionToFunctionSet : public vtkFunction
 public:
   static vtkTensorImplicitFunctionToFunctionSet *New();
   vtkTypeMacro(vtkTensorImplicitFunctionToFunctionSet, vtkFunctionSet );
-  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
-  virtual int FunctionValues(double* x, double* f) VTK_OVERRIDE;
+  virtual void PrintSelf(ostream& os, vtkIndent indent) override;
+  virtual int FunctionValues(double* x, double* f) override;
   int GetTensor(double *x, double * f);
   virtual void AddDataSet(vtkDataSet* ) {}
   void AddImplicitFunction(vtkImplicitFunction * func, int numcomp ) {

--- a/Libs/vtkDMRI/vtkTensorMask.h
+++ b/Libs/vtkDMRI/vtkTensorMask.h
@@ -41,7 +41,7 @@ public:
   vtkTypeMacro(vtkTensorMask,vtkImageMask);
 
   static vtkTensorMask *New();
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
 protected:
   vtkTensorMask();
@@ -52,14 +52,14 @@ protected:
   /// We override this in order to allocate output tensors
   /// before threading happens.  This replaces the superclass
   /// vtkImageAlgorithm's Execute function.
-  void ExecuteData(vtkDataObject *out) VTK_OVERRIDE;
+  void ExecuteData(vtkDataObject *out) override;
 
   virtual void ThreadedRequestData(vtkInformation *request,
                                    vtkInformationVector **inputVector,
                                    vtkInformationVector *outputVector,
                                    vtkImageData ***inData,
                                    vtkImageData **outData,
-                                   int extent[6], int threadId) VTK_OVERRIDE;
+                                   int extent[6], int threadId) override;
 };
 
 #endif

--- a/Libs/vtkDMRI/vtkTensorRotate.h
+++ b/Libs/vtkDMRI/vtkTensorRotate.h
@@ -34,7 +34,7 @@ class vtkDMRI_EXPORT vtkTensorRotate : public vtkThreadedImageAlgorithm
 public:
   static vtkTensorRotate *New();
   vtkTypeMacro(vtkTensorRotate,vtkThreadedImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Set the tensor type for the filter
   void SetTensorTypeToFloat(){this->SetTensorType(VTK_FLOAT);};
@@ -52,14 +52,14 @@ protected:
   vtkTensorRotate(const vtkTensorRotate&);
   void operator=(const vtkTensorRotate&);
 
-  virtual int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE;
+  virtual int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
   void ThreadedExecute(vtkImageData *inData, vtkImageData *outData,
-        int extent[6], int id) VTK_OVERRIDE;
+        int extent[6], int id) override;
 
   /// This also copies other arrays from point and cell data from input to output.
-  virtual void AllocateOutputData(vtkImageData *out, vtkInformation* outInfo, int *uExtent) VTK_OVERRIDE {
+  virtual void AllocateOutputData(vtkImageData *out, vtkInformation* outInfo, int *uExtent) override {
       vtkThreadedImageAlgorithm::AllocateOutputData(out, outInfo, uExtent);};
-  virtual vtkImageData *AllocateOutputData(vtkDataObject *out, vtkInformation* outInfo) VTK_OVERRIDE;
+  virtual vtkImageData *AllocateOutputData(vtkDataObject *out, vtkInformation* outInfo) override;
   void AllocateTensors(vtkImageData *data);
 
   int TensorType;

--- a/Modules/CLI/FiberBundleLabelSelect/FiberBundleLabelSelect.cxx
+++ b/Modules/CLI/FiberBundleLabelSelect/FiberBundleLabelSelect.cxx
@@ -159,7 +159,12 @@ int main( int argc, char * argv[] )
   vtkIdType numPts = inPts->GetNumberOfPoints();
   vtkCellArray *inLines = input->GetLines();
   vtkIdType numLines = inLines->GetNumberOfCells();
-  vtkIdType npts=0, sampledNpts=0, *pts=NULL;
+  vtkIdType npts=0, sampledNpts=0;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  const vtkIdType*pts;
+#else
+  vtkIdType*pts=NULL;
+#endif
 
   if ( !inPts || numPts  < 1 || !inLines || numLines < 1 )
     {

--- a/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.h
+++ b/Modules/Loadable/InteractiveSeeding/Logic/vtkMRMLTractographyInteractiveSeedingNode.h
@@ -35,27 +35,27 @@ class VTK_SLICER_TRACTOGRAPHYINTERACTIVESEEDING_MODULE_LOGIC_EXPORT vtkMRMLTract
 public:
   static vtkMRMLTractographyInteractiveSeedingNode *New();
   vtkTypeMacro(vtkMRMLTractographyInteractiveSeedingNode,vtkMRMLNode);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Create instance of a GAD node.
-  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNodeInstance() override;
 
   // Description:
   // Set node attributes from name/value pairs
-  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
+  virtual void ReadXMLAttributes( const char** atts) override;
 
   // Description:
   // Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
+  virtual void WriteXML(ostream& of, int indent) override;
 
   // Description:
   // Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
+  virtual void Copy(vtkMRMLNode *node) override;
 
   // Description:
   // Get unique node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "FiducialSeedingParameters";};
+  virtual const char* GetNodeTagName() override {return "FiducialSeedingParameters";};
 
   // Description:
   // Get/Set Threshold Mode (module parameter)
@@ -188,7 +188,7 @@ public:
 
   // Description:
   // Update the stored reference to another node in the scene
-  virtual void UpdateReferenceID(const char *oldID, const char *newID) VTK_OVERRIDE;
+  virtual void UpdateReferenceID(const char *oldID, const char *newID) override;
 
   void StringToROILabels(std::string labels);
 

--- a/Modules/Loadable/InteractiveSeeding/Logic/vtkSlicerTractographyInteractiveSeedingLogic.h
+++ b/Modules/Loadable/InteractiveSeeding/Logic/vtkSlicerTractographyInteractiveSeedingLogic.h
@@ -44,11 +44,11 @@ public:
   // The Usual vtk class functions
   static vtkSlicerTractographyInteractiveSeedingLogic *New();
   vtkTypeMacro(vtkSlicerTractographyInteractiveSeedingLogic,vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   virtual void ProcessMRMLNodesEvents(vtkObject* caller,
                                       unsigned long event,
-                                      void * callData) VTK_OVERRIDE;
+                                      void * callData) override;
 
   // Get parameters node
   vtkGetObjectMacro (TractographyInteractiveSeedingNode, vtkMRMLTractographyInteractiveSeedingNode);
@@ -107,10 +107,10 @@ protected:
 
   /// Register node classes into the mrml scene. Called each time a new scene
   /// is set. Do nothing by default. Can be reimplemented in derivated classes.
-  virtual void RegisterNodes() VTK_OVERRIDE;
+  virtual void RegisterNodes() override;
 
   // Initialize listening to MRML events
-  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene) VTK_OVERRIDE;
+  virtual void SetMRMLSceneInternal(vtkMRMLScene * newScene) override;
 
   // set and observe the 0th parameter node in the scene, looking for it by
   // class vtkMRMLTractographyInteractiveSeedingNode. Called when the scene
@@ -118,11 +118,11 @@ protected:
   void SelectFirstParameterNode();
 
   /// Respond to MRML events
-  virtual void OnMRMLSceneEndImport() VTK_OVERRIDE;
-  virtual void OnMRMLSceneEndRestore() VTK_OVERRIDE;
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual void OnMRMLSceneEndImport() override;
+  virtual void OnMRMLSceneEndRestore() override;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
 
-  virtual void OnMRMLNodeModified(vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual void OnMRMLNodeModified(vtkMRMLNode* node) override;
 
   void AddMRMLNodesObservers();
 

--- a/Modules/Loadable/TractIO/TractIOCLI/VTK_to_DICOMTract.cxx
+++ b/Modules/Loadable/TractIO/TractIOCLI/VTK_to_DICOMTract.cxx
@@ -410,7 +410,11 @@ int insert_polydata_scalars(TrcTrackSet* trackset,
     //OFCondition res = TrcMeasurement::create(typeCode, unitCode, measurement);
     OFCondition res = trackset->addMeasurement(typeCode, unitCode, measurement);
 
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+    const vtkIdType* ptids;
+#else
     vtkIdType* ptids;
+#endif
     vtkIdType numpts;
     lines->InitTraversal();
     size_t track_idx = 0;

--- a/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.h
+++ b/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.h
@@ -36,7 +36,7 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_LOGIC_EXPORT vtkSlicerFiberBundleLog
   // The Usual vtk class functions
   static vtkSlicerFiberBundleLogic *New();
   vtkTypeMacro(vtkSlicerFiberBundleLogic,vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Create new mrml fiber bundle node and read its polydata from a specified file.
@@ -60,10 +60,10 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_LOGIC_EXPORT vtkSlicerFiberBundleLog
   // Description:
   // Register MRML Node classes to Scene.
   // Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes() VTK_OVERRIDE;
+  virtual void RegisterNodes() override;
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene*) VTK_OVERRIDE;
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode*) VTK_OVERRIDE;
+  virtual void SetMRMLSceneInternal(vtkMRMLScene*) override;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode*) override;
 
 protected:
   vtkSlicerFiberBundleLogic();

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleDisplayNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleDisplayNode.h
@@ -34,7 +34,7 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleDispla
 {
  public:
   vtkTypeMacro(vtkMRMLFiberBundleDisplayNode, vtkMRMLModelDisplayNode);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   //--------------------------------------------------------------------------
   /// MRMLNode methods
@@ -42,32 +42,32 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleDispla
 
   ///
   /// Read node attributes from XML (MRML) file
-  virtual void ReadXMLAttributes ( const char** atts ) VTK_OVERRIDE;
+  virtual void ReadXMLAttributes ( const char** atts ) override;
 
   ///
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML ( ostream& of, int indent ) VTK_OVERRIDE;
+  virtual void WriteXML ( ostream& of, int indent ) override;
 
   ///
   /// Copy the node's attributes to this object
-  virtual void Copy ( vtkMRMLNode *node ) VTK_OVERRIDE;
+  virtual void Copy ( vtkMRMLNode *node ) override;
 
   ///
   /// Get node XML tag name (like Volume, FiberBundle)
-  virtual const char* GetNodeTagName() VTK_OVERRIDE = 0;
+  virtual const char* GetNodeTagName() override = 0;
 
   ///
   /// Updates this node if it depends on other nodes
   /// when the node is deleted in the scene
-  virtual void UpdateReferences() VTK_OVERRIDE;
+  virtual void UpdateReferences() override;
 
   ///
   /// Finds the storage node and read the data
-  virtual void UpdateScene(vtkMRMLScene *scene) VTK_OVERRIDE;
+  virtual void UpdateScene(vtkMRMLScene *scene) override;
 
   ///
   /// Update the stored reference to another node in the scene
-  virtual void UpdateReferenceID(const char *oldID, const char *newID) VTK_OVERRIDE;
+  virtual void UpdateReferenceID(const char *oldID, const char *newID) override;
 
   //--------------------------------------------------------------------------
   /// Display Information: Geometry to display (not mutually exclusive)
@@ -183,13 +183,13 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleDispla
   static int GetNthScalarInvariant(int i);
 
   /// Update the pipeline based on this node attributes
-  virtual void UpdateAssignedAttribute() VTK_OVERRIDE;
+  virtual void UpdateAssignedAttribute() override;
 
   virtual void ProcessMRMLEvents ( vtkObject *caller,
                                  unsigned long event,
-                                 void *callData ) VTK_OVERRIDE;
+                                 void *callData ) override;
 
-  virtual void SetInputMeshConnection (vtkAlgorithmOutput*) VTK_OVERRIDE;
+  virtual void SetInputMeshConnection (vtkAlgorithmOutput*) override;
 
  protected:
   vtkMRMLFiberBundleDisplayNode ( );

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleGlyphDisplayNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleGlyphDisplayNode.h
@@ -33,34 +33,34 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleGlyphD
  public:
   static vtkMRMLFiberBundleGlyphDisplayNode *New (  );
   vtkTypeMacro ( vtkMRMLFiberBundleGlyphDisplayNode,vtkMRMLFiberBundleDisplayNode );
-  void PrintSelf ( ostream& os, vtkIndent indent ) VTK_OVERRIDE;
+  void PrintSelf ( ostream& os, vtkIndent indent ) override;
 
   //--------------------------------------------------------------------------
   /// MRMLNode methods
   //--------------------------------------------------------------------------
 
-  virtual vtkMRMLNode* CreateNodeInstance (  ) VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNodeInstance (  ) override;
 
   ///
   /// Read node attributes from XML (MRML) file
-  virtual void ReadXMLAttributes ( const char** atts ) VTK_OVERRIDE;
+  virtual void ReadXMLAttributes ( const char** atts ) override;
 
   ///
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML ( ostream& of, int indent ) VTK_OVERRIDE;
+  virtual void WriteXML ( ostream& of, int indent ) override;
 
 
   ///
   /// Copy the node's attributes to this object
-  virtual void Copy ( vtkMRMLNode *node ) VTK_OVERRIDE;
+  virtual void Copy ( vtkMRMLNode *node ) override;
 
   ///
   /// Get node XML tag name (like Volume, UnstructuredGrid)
-  virtual const char* GetNodeTagName ( )  VTK_OVERRIDE {return "FiberBundleGlyphDisplayNode";};
+  virtual const char* GetNodeTagName ( )  override {return "FiberBundleGlyphDisplayNode";};
 
   ///
   /// Update the pipeline based on this node attributes
-  virtual void UpdateAssignedAttribute() VTK_OVERRIDE;
+  virtual void UpdateAssignedAttribute() override;
 
   //--------------------------------------------------------------------------
   /// Display Information: Geometry to display (not mutually exclusive)
@@ -79,7 +79,7 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleGlyphD
   void operator= ( const vtkMRMLFiberBundleGlyphDisplayNode& );
 
   /// Gets result in glyph PolyData
-  virtual vtkAlgorithmOutput* GetOutputMeshConnection() VTK_OVERRIDE;
+  virtual vtkAlgorithmOutput* GetOutputMeshConnection() override;
 
   /// Enumerated
 

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleLineDisplayNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleLineDisplayNode.h
@@ -35,21 +35,21 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleLineDi
  public:
   static vtkMRMLFiberBundleLineDisplayNode *New (  );
   vtkTypeMacro ( vtkMRMLFiberBundleLineDisplayNode, vtkMRMLFiberBundleDisplayNode );
-  void PrintSelf ( ostream& os, vtkIndent indent ) VTK_OVERRIDE;
+  void PrintSelf ( ostream& os, vtkIndent indent ) override;
 
   //--------------------------------------------------------------------------
   /// MRMLNode methods
   //--------------------------------------------------------------------------
 
-  virtual vtkMRMLNode* CreateNodeInstance (  ) VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNodeInstance (  ) override;
 
   ///
   /// Get node XML tag name (like Volume, UnstructuredGrid)
-  virtual const char* GetNodeTagName ( ) VTK_OVERRIDE {return "FiberBundleLineDisplayNode";};
+  virtual const char* GetNodeTagName ( ) override {return "FiberBundleLineDisplayNode";};
 
   ///
   /// Update the pipeline based on this node attributes
-  virtual void UpdateAssignedAttribute() VTK_OVERRIDE;
+  virtual void UpdateAssignedAttribute() override;
 
 
  protected:
@@ -59,7 +59,7 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleLineDi
   void operator= ( const vtkMRMLFiberBundleLineDisplayNode& );
 
   /// Reimplemented to return the output of the display pipeline
-  virtual vtkAlgorithmOutput* GetOutputMeshConnection() VTK_OVERRIDE;
+  virtual vtkAlgorithmOutput* GetOutputMeshConnection() override;
 
   /// display pipeline
   vtkPolyDataTensorToColor *TensorToColor;

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
@@ -43,45 +43,45 @@ public:
   static vtkMRMLFiberBundleNode *New();
   vtkTypeMacro(vtkMRMLFiberBundleNode,vtkMRMLModelNode);
   //vtkTypeMacro(vtkMRMLFiberBundleNode,vtkMRMLTransformableNode);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   //--------------------------------------------------------------------------
   /// MRMLNode methods
   //--------------------------------------------------------------------------
 
-  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNodeInstance() override;
 
   ///
   /// Read node attributes from XML (MRML) file
-  virtual void ReadXMLAttributes ( const char** atts ) VTK_OVERRIDE;
+  virtual void ReadXMLAttributes ( const char** atts ) override;
 
   ///
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML ( ostream& of, int indent ) VTK_OVERRIDE;
+  virtual void WriteXML ( ostream& of, int indent ) override;
 
 
   ///
   /// Copy the node's attributes to this object
-  virtual void Copy ( vtkMRMLNode *node ) VTK_OVERRIDE;
+  virtual void Copy ( vtkMRMLNode *node ) override;
 
   ///
   /// alternative method to propagate events generated in Display nodes
   virtual void ProcessMRMLEvents ( vtkObject * /*caller*/,
                                    unsigned long /*event*/,
-                                   void * /*callData*/ ) VTK_OVERRIDE;
+                                   void * /*callData*/ ) override;
 
   ///
   /// Updates this node if it depends on other nodes
   /// when the node is deleted in the scene
-  virtual void UpdateReferences() VTK_OVERRIDE;
+  virtual void UpdateReferences() override;
 
   ///
   /// Update the stored reference to another node in the scene
-  virtual void UpdateReferenceID(const char *oldID, const char *newID) VTK_OVERRIDE;
+  virtual void UpdateReferenceID(const char *oldID, const char *newID) override;
 
   ///
   /// Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "FiberBundle";};
+  virtual const char* GetNodeTagName() override {return "FiberBundle";};
 
   /// Get the subsampling ratio for the polydata
   vtkGetMacro(SubsamplingRatio, float);
@@ -137,13 +137,13 @@ public:
 
   ///
   /// Reimplemented from internal reasons
-  virtual void SetMeshConnection(vtkAlgorithmOutput* inputPort) VTK_OVERRIDE;
+  virtual void SetMeshConnection(vtkAlgorithmOutput* inputPort) override;
 
   ///
   /// Gets the subsampled PolyData converted from the real data in the node
   virtual vtkPointSet* GetFilteredPolyData();
   virtual vtkAlgorithmOutput* GetFilteredMeshConnection();
-  void SetMeshToDisplayNode(vtkMRMLModelDisplayNode*) VTK_OVERRIDE;
+  void SetMeshToDisplayNode(vtkMRMLModelDisplayNode*) override;
 
   ///
   /// get associated line display node or NULL if not set
@@ -159,12 +159,12 @@ public:
 
   ///
   /// Create and return default storage node or NULL if does not have one
-  virtual vtkMRMLStorageNode* CreateDefaultStorageNode() VTK_OVERRIDE;
+  virtual vtkMRMLStorageNode* CreateDefaultStorageNode() override;
 
   std::string GetDefaultStorageNodeClassName(const char* filename /* =nullptr */) override;
 
   /// Create default display nodes
-  virtual void CreateDefaultDisplayNodes() VTK_OVERRIDE;
+  virtual void CreateDefaultDisplayNodes() override;
 
    // Description:
   // Get the maximum number of fibers to show by default when a new fiber bundle node is set

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleStorageNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleStorageNode.h
@@ -31,21 +31,21 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleStorag
   vtkTypeMacro(vtkMRMLFiberBundleStorageNode,vtkMRMLModelStorageNode);
   //void PrintSelf(ostream& os, vtkIndent indent);
 
-  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNodeInstance() override;
 
   ///
   /// Get node XML tag name (like Storage, Model)
-  virtual const char* GetNodeTagName()  VTK_OVERRIDE {return "FiberBundleStorage";};
+  virtual const char* GetNodeTagName()  override {return "FiberBundleStorage";};
 
   ///
   /// Check to see if this storage node can handle the file type in the input
   /// string. If input string is null, check URI, then check FileName.
   /// Subclasses should implement this method.
-  virtual int SupportedFileType(const char *fileName) VTK_OVERRIDE;
+  virtual int SupportedFileType(const char *fileName) override;
 
   ///
   /// Initialize all the supported write file types
-  virtual void InitializeSupportedWriteFileTypes() VTK_OVERRIDE;
+  virtual void InitializeSupportedWriteFileTypes() override;
 
 protected:
   vtkMRMLFiberBundleStorageNode();

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleTubeDisplayNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleTubeDisplayNode.h
@@ -34,34 +34,34 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleTubeDi
  public:
   static vtkMRMLFiberBundleTubeDisplayNode *New (  );
   vtkTypeMacro ( vtkMRMLFiberBundleTubeDisplayNode, vtkMRMLFiberBundleDisplayNode );
-  void PrintSelf ( ostream& os, vtkIndent indent ) VTK_OVERRIDE;
+  void PrintSelf ( ostream& os, vtkIndent indent ) override;
 
   //--------------------------------------------------------------------------
   /// MRMLNode methods
   //--------------------------------------------------------------------------
 
-  virtual vtkMRMLNode* CreateNodeInstance (  ) VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNodeInstance (  ) override;
 
   ///
   /// Read node attributes from XML (MRML) file
-  virtual void ReadXMLAttributes ( const char** atts ) VTK_OVERRIDE;
+  virtual void ReadXMLAttributes ( const char** atts ) override;
 
   ///
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML ( ostream& of, int indent ) VTK_OVERRIDE;
+  virtual void WriteXML ( ostream& of, int indent ) override;
 
 
   ///
   /// Copy the node's attributes to this object
-  virtual void Copy ( vtkMRMLNode *node ) VTK_OVERRIDE;
+  virtual void Copy ( vtkMRMLNode *node ) override;
 
   ///
   /// Get node XML tag name (like Volume, UnstructuredGrid)
-  virtual const char* GetNodeTagName ( ) VTK_OVERRIDE {return "FiberBundleTubeDisplayNode";};
+  virtual const char* GetNodeTagName ( ) override {return "FiberBundleTubeDisplayNode";};
 
   ///
   /// Update the pipeline based on this node attributes
-  virtual void UpdateAssignedAttribute() VTK_OVERRIDE;
+  virtual void UpdateAssignedAttribute() override;
 
   //--------------------------------------------------------------------------
   /// Display Information: Geometry to display (not mutually exclusive)
@@ -86,7 +86,7 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleTubeDi
 
   ///
   /// Gets resultin glyph PolyData
-  virtual vtkAlgorithmOutput* GetOutputMeshConnection() VTK_OVERRIDE;
+  virtual vtkAlgorithmOutput* GetOutputMeshConnection() override;
 
   /// Enumerated
 

--- a/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.cxx
@@ -322,7 +322,12 @@ void vtkMRMLTractographyDisplayDisplayableManager::SelectPickedFibers(vtkMRMLFib
 
   // copy polydata
   vtkIdType npts;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  const vtkIdType* pts;
+#else
   vtkIdType* pts;
+#endif
+
   vtkPolyData *polyData = vtkPolyData::New();
   polyData->DeepCopy(fiberBundleNode->GetPolyData());
   if (polyData->GetPointData() == NULL || polyData->GetPointData()->GetArray(0) == NULL)

--- a/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.h
+++ b/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.h
@@ -40,7 +40,7 @@ class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRMLDM_EXPORT vtkMRMLTractographyDis
 public:
   static vtkMRMLTractographyDisplayDisplayableManager *New();
   vtkTypeMacro(vtkMRMLTractographyDisplayDisplayableManager, vtkMRMLAbstractThreeDViewDisplayableManager);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   vtkGetMacro(EnableFiberEdit, int);
   vtkSetMacro(EnableFiberEdit, int);
@@ -51,12 +51,12 @@ protected:
   vtkMRMLTractographyDisplayDisplayableManager(const vtkMRMLTractographyDisplayDisplayableManager&);
   void operator=(const vtkMRMLTractographyDisplayDisplayableManager&);
 
-  virtual int ActiveInteractionModes() VTK_OVERRIDE;
+  virtual int ActiveInteractionModes() override;
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene) VTK_OVERRIDE;
-  virtual void ProcessMRMLNodesEvents(vtkObject *caller, unsigned long event, void *callData) VTK_OVERRIDE;
+  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene) override;
+  virtual void ProcessMRMLNodesEvents(vtkObject *caller, unsigned long event, void *callData) override;
 
-  virtual void OnInteractorStyleEvent(int eventId) VTK_OVERRIDE;
+  virtual void OnInteractorStyleEvent(int eventId) override;
 
   vtkMRMLFiberBundleNode* GetPickedFiber(vtkMRMLFiberBundleDisplayNode* displayNode,
                                                          vtkIdType pickedCell, vtkIdType &cellID);

--- a/Modules/Loadable/TractographyDisplay/Testing/Cxx/vtkMRMLFiberBundleDisplayNodeTest1.cxx
+++ b/Modules/Loadable/TractographyDisplay/Testing/Cxx/vtkMRMLFiberBundleDisplayNodeTest1.cxx
@@ -26,7 +26,7 @@ public:
 
   vtkTypeMacro(vtkMRMLFiberBundleDisplayNodeTestHelper1,vtkMRMLFiberBundleDisplayNode);
 
-  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE
+  virtual vtkMRMLNode* CreateNodeInstance() override
     {
     return vtkMRMLFiberBundleDisplayNodeTestHelper1::New();
     }
@@ -42,7 +42,7 @@ public:
     return EXIT_SUCCESS;
     }
 
-  virtual const char* GetNodeTagName() VTK_OVERRIDE
+  virtual const char* GetNodeTagName() override
     {
     return "Testing is good";
     }


### PR DESCRIPTION
* Replace `VTK_OVERRIDE` with override

* Update initialization of `vtkIdType*` ivar to comply
  with updated `vtkPolyData` API.

* Fix `vtkDMRI` python wrapping excluding `PythonD` target with `VTK >= 8.90`
  It fixes the following configuration error:

  ```
  CMake Error at Libs/vtkDMRI/CMakeLists.txt:125 (set_target_properties):
    set_target_properties Can not find target to add properties to:
    vtkDMRIPythonD

  CMake Error at Libs/vtkDMRI/CMakeLists.txt:131 (export):
    export given target "vtkDMRIPythonD" which is not built by this project.
  ```