### PR TITLE
Fixed vendor name bug and removed erroneous tags

### DIFF
--- a/Modules/Scripted/DMRIPlugins/DICOMDiffusionVolumePlugin.py
+++ b/Modules/Scripted/DMRIPlugins/DICOMDiffusionVolumePlugin.py
@@ -113,7 +113,7 @@ class DICOMDiffusionVolumePluginClass(DICOMPlugin):
       loadable.files = files
       loadable.name = name + ' - as DWI Volume'
       loadable.selected = True
-      loadable.tooltip = "Matches DICOM tags for the following vendor(s): %s" % (", ".join(matchingVendors)
+      loadable.tooltip = "Matches DICOM tags for the following vendor(s): %s" % (", ".join(matchingVendors))
       loadable.confidence = 0.6
       loadables = [loadable]
     return loadables


### PR DESCRIPTION
Previous code always assigned "Philips" as vendor if any tags for any vendor
matched. Also removed two tags which matched non-DWI Siemens volume.
Those tags were left as comments in case someone in the future wants to treat
those with more nuance and put them back in. Adjusted loadable tooltip to
list all matching vendors.