### PR TITLE
Parallel load of vtp fiber bundles

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Widgets/Resources/UI/qSlicerTractographyDisplayModuleWidget.ui
+++ b/Modules/Loadable/TractographyDisplay/Widgets/Resources/UI/qSlicerTractographyDisplayModuleWidget.ui
@@ -62,6 +62,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="addDirectory" native="true">
+     <property name="text">
+      <string>Add fibers from directory...</string>
+     </property>
+     <property name="toolTip">
+      <string>Select a directory containing .vtp files to load in parallel</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QWidget" name="percentageWidget" native="true">
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.cxx
@@ -16,6 +16,7 @@
 // Qt includes
 #include <QtConcurrent/QtConcurrent>
 #include <QDir>
+#include <QFileDialog>
 #include <QFuture>
 #include <QFutureSynchronizer>
 #include <QFutureWatcher>
@@ -76,6 +77,8 @@ void qSlicerTractographyDisplayModuleWidgetPrivate::init()
 
   this->percentageOfFibersShown->setTracking(false);
 
+  QObject::connect(this->addDirectory, SIGNAL(clicked()),
+                   q, SLOT(onAddDirectory()));
   QObject::connect(this->percentageOfFibersShown, SIGNAL(valueChanged(double)),
                    q, SLOT(setPercentageOfFibersShown(double)));
   QObject::connect(q, SIGNAL(percentageOfFibersShownChanged(double)),
@@ -225,6 +228,16 @@ void qSlicerTractographyDisplayModuleWidget::setSolidTubeColor(bool solid)
     }
 }
 
+//-----------------------------------------------------------
+void qSlicerTractographyDisplayModuleWidget::onAddDirectory()
+{
+  QString directoryPath = QFileDialog::getExistingDirectory(this, "Directory to add");
+  if (directoryPath != "")
+    {
+    this->loadThreaded(directoryPath);
+    }
+}
+
 
 //-----------------------------------------------------------
 
@@ -263,21 +276,11 @@ public:
 //-----------------------------------------------------------
 bool qSlicerTractographyDisplayModuleWidget::loadThreaded(QString directoryPath)
 {
-  QString path = "/opt/data/SlicerDMRI/ABCD-Harmonization/WMA/tar_sub-NDARINV0UA196B6_ses_newPara/AnatomicalTracts";
-  //path = "/opt/data/SlicerDMRI/ABCD-Harmonization/WMA/tar_harmonized_sub-NDARINV0UA196B6_ses_newPara/TractSubset";
-  /*
-slicer.modules.tractographydisplay.widgetRepresentation().loadThreaded("")
-   */
-  if (directoryPath != "")
-    {
-    path = directoryPath;
-    }
-
   this->mrmlScene()->StartState(vtkMRMLScene::ImportState);
 
   QFutureSynchronizer<void> futureSynchrnonizer;
 
-  QDir dir(path);
+  QDir dir(directoryPath);
   QStringList nameFilter;
   nameFilter << "*.vtp";
   foreach(QString fileName, dir.entryList(nameFilter)) {
@@ -287,7 +290,7 @@ slicer.modules.tractographydisplay.widgetRepresentation().loadThreaded("")
 
     FiberReader reader;
 
-    QFuture<ReaderType> future = reader.read(miniScene, path+"/"+fileName);
+    QFuture<ReaderType> future = reader.read(miniScene, directoryPath+"/"+fileName);
     futureSynchrnonizer.addFuture(future);
 
     QFutureWatcher<ReaderType> *watcher = new QFutureWatcher<ReaderType>();

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.h
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.h
@@ -48,6 +48,8 @@ public:
   virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString()) override;
   virtual double nodeEditable(vtkMRMLNode* node) override;
 
+  Q_INVOKABLE virtual bool loadThreaded(QString directoryPath);
+
 public slots:
   void setFiberBundleNode(vtkMRMLNode*);
   void setFiberBundleNode(vtkMRMLFiberBundleNode*);

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.h
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.h
@@ -55,6 +55,7 @@ public slots:
   void setFiberBundleNode(vtkMRMLFiberBundleNode*);
   void setPercentageOfFibersShown(double);
   void setSolidTubeColor(bool);
+  void onAddDirectory();
 
 signals:
   void percentageOfFibersShownChanged(double);


### PR DESCRIPTION
This is ready for testing.  The feature is a bit rough and we should discuss how to better integrate it with the gui and what features to add.  E.g. it needs a progress bar.

Currently you select a directory filled with .vtp files and it does the file reading and some of the mrml operations in dedicated threads.

Here's a comparison of the traditional load on the right and the parallel load on the left:

https://www.dropbox.com/t/Iw1RoZmavrq2Y3bb