### PR TITLE
BUG: fix tracts for vtk9

### DIFF
--- a/Libs/vtkDMRI/vtkSeedTracts.cxx
+++ b/Libs/vtkDMRI/vtkSeedTracts.cxx
@@ -933,6 +933,14 @@ void vtkSeedTracts::TransformStreamlinesToRASAndAppendToPolyData(vtkPolyData *ou
     // -------------------------------------------------
     }
 
+#ifdef VTK_CELL_ARRAY_V2
+  // For vtk9 vtkCellArray::GetData returns a copy of the structure,
+  // so we aren't manipulating the real array as in previous versions.
+  // So we must copy the data into the actual structure used by the vtkPolyData.
+  // https://discourse.vtk.org/t/upcoming-changes-to-vtkcellarray/2066
+  outFibersCellArray->ImportLegacyFormat(cellArray);
+#endif
+
   // Remove the scalars if any, we don't need
   // to save anything but the tensors
   outFibers->GetPointData()->SetScalars(NULL);


### PR DESCRIPTION
The behavior of vtkCellArray::GetData changed with vtk9 such
that is now returns a copy of the data rather than the actual
array, so manipulating it has no effect.

Instead now we must have the cell array import the legacy format.

This operation is no doubt slower but is a minimal change to restore
funcationality.  This code should really be threaded and reworked to
use the new API if performance is critical.