### PR TITLE
COMP: fix copydata ambiguity and missing math.h

### DIFF
--- a/Libs/vtkDMRI/vtkBSplineInterpolateImageFunction.cxx
+++ b/Libs/vtkDMRI/vtkBSplineInterpolateImageFunction.cxx
@@ -17,6 +17,8 @@
 #include "vtkImageData.h"  // for storing output of vtk/itk filter
 #include <vtkVersion.h>
 
+#include <math.h>
+
 vtkStandardNewMacro(vtkBSplineInterpolateImageFunction);
 
 void vtkBSplineInterpolateImageFunction::SetInterpolationWeights(

--- a/Libs/vtkDMRI/vtkPolyDataTensorToColor.cxx
+++ b/Libs/vtkDMRI/vtkPolyDataTensorToColor.cxx
@@ -377,7 +377,8 @@ int vtkPolyDataTensorToColor::RequestData(
       // TO DO: why does superclass have this if no scalar output?
       // in this case it appears copy scalars is on (above in
       // scalar allocation section).
-      outPD->CopyData(pd,0,ptOffset);
+      vtkIdType start = 0;
+      outPD->CopyData(pd,start,ptOffset);
     }
 
     // Keep track of the number of points output so far.


### PR DESCRIPTION
Fixes two build errors related to updated VTK.

First was a missing math.h include and second was an ambiguous method invocation.

```
Building CXX object Libs/vtkDMRI/CMakeFiles/vtkDMRI.dir/vtkPolyDataTensorToColor.cxx.o
/home/pieper/slicer4/latest/Extensions/ExtensionsIndex-build/SlicerDMRI/Libs/vtkDMRI/vtkPolyDataTensorToColor.cxx: In member function ‘virtual int vtkPolyDataTensorToColor::RequestData(vtkInformation*, vtkInformationVector**, vtkInformationVector*)’:
/home/pieper/slicer4/latest/Extensions/ExtensionsIndex-build/SlicerDMRI/Libs/vtkDMRI/vtkPolyDataTensorToColor.cxx:380:36: error: call of overloaded ‘CopyData(vtkPointData*&, int, vtkIdType&)’ is ambiguous
  380 |       outPD->CopyData(pd,0,ptOffset);
      |                                    ^
In file included from /home/pieper/slicer4/latest/Slicer-superbuild/VTK/Common/DataModel/vtkPointData.h:29,
                 from /home/pieper/slicer4/latest/Extensions/ExtensionsIndex-build/SlicerDMRI/Libs/vtkDMRI/vtkPolyDataTensorToColor.cxx:21:
/home/pieper/slicer4/latest/Slicer-superbuild/VTK/Common/DataModel/vtkDataSetAttributes.h:519:8: note: candidate: ‘void vtkDataSetAttributes::CopyData(vtkDataSetAttributes*, vtkIdType, vtkIdType)’
  519 |   void CopyData(vtkDataSetAttributes* fromPd, vtkIdType fromId, vtkIdType toId);
      |        ^~~~~~~~
/home/pieper/slicer4/latest/Slicer-superbuild/VTK/Common/DataModel/vtkDataSetAttributes.h:521:8: note: candidate: ‘void vtkDataSetAttributes::CopyData(vtkDataSetAttributes*, vtkIdList*, vtkIdType)’
  521 |   void CopyData(vtkDataSetAttributes* fromPd, vtkIdList* fromIds, vtkIdType destStartId = 0);
      |        ^~~~~~~~
make[5]: *** [Libs/vtkDMRI/CMakeFiles/vtkDMRI.dir/build.make:100: Libs/vtkDMRI/CMakeFiles/vtkDMRI.dir/vtkPolyDataTensorToColor.cxx.o] Error 1
make[4]: *** [CMakeFiles/Makefile2:1753: Libs/vtkDMRI/CMakeFiles/vtkDMRI.dir/all] Error 2
make[3]: *** [Makefile:163: all] Error 2
make[2]: *** [CMakeFiles/inner.dir/build.make:113: inner-prefix/src/inner-stamp/inner-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:239: CMakeFiles/inner.dir/all] Error 2
make: *** [Makefile:95: all] Error 2

```