### PR TITLE
COMP: Fix build error with C++17

### DIFF
--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
@@ -554,7 +554,11 @@ void vtkMRMLFiberBundleNode::UpdateSubsampling()
       idVector.push_back(i);
 
     if (this->EnableShuffleIDs)
-      std::random_shuffle(idVector.begin(), idVector.end());
+      {
+      std::random_device randomDevice;
+      std::mt19937 randomGenerator(randomDevice());
+      std::shuffle(idVector.begin(), idVector.end(), randomGenerator);
+      }
 
     this->ShuffledIds->Initialize();
 


### PR DESCRIPTION
Fixes build error "no member named 'random_shuffle' in namespace 'std'"
(https://slicer.cdash.org/viewBuildError.php?buildid=2735613)

The error is due to `random_shuffle` was deprecated in C++14 and removed in C++17.
The replacement `shuffle` function takes a random generator as parameter.
More details: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4190.htm