### PR TITLE
Fix registration of Tractography displayable manager and remove support for Qt4 and Slicer 4

### DIFF
--- a/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModule.cxx
+++ b/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModule.cxx
@@ -6,13 +6,6 @@
 #include "qSlicerTractographyInteractiveSeedingModuleWidget.h"
 
 //-----------------------------------------------------------------------------
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-// QT includes
-#include <QtPlugin>
-Q_EXPORT_PLUGIN2(qSlicerTractographyInteractiveSeedingModule, qSlicerTractographyInteractiveSeedingModule);
-#endif
-
-//-----------------------------------------------------------------------------
 qSlicerTractographyInteractiveSeedingModule::
 qSlicerTractographyInteractiveSeedingModule(QObject* _parent):Superclass(_parent)
 {

--- a/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModule.h
+++ b/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModule.h
@@ -13,9 +13,7 @@ class qSlicerTractographyInteractiveSeedingModuleWidget;
 class Q_SLICER_QTMODULES_TRACTOGRAPHYINTERACTIVESEEDING_EXPORT qSlicerTractographyInteractiveSeedingModule : public qSlicerLoadableModule
 {
   Q_OBJECT
-#ifdef Slicer_HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
-#endif
   Q_INTERFACES(qSlicerLoadableModule);
 public:
   typedef qSlicerLoadableModule Superclass;

--- a/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.h
+++ b/Modules/Loadable/InteractiveSeeding/qSlicerTractographyInteractiveSeedingModuleWidget.h
@@ -4,7 +4,7 @@
 // CTK includes
 #include <ctkPimpl.h>
 
-// SlicerQt includes
+// Slicer includes
 #include "qSlicerAbstractModuleWidget.h"
 
 #include "qSlicerTractographyInteractiveSeedingModuleExport.h"

--- a/Modules/Loadable/TractographyDisplay/Widgets/qMRMLTractographyDisplayTreeView.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qMRMLTractographyDisplayTreeView.cxx
@@ -94,13 +94,8 @@ void qMRMLTractographyDisplayTreeViewPrivate::init()
 
   q->header()->setStretchLastSection(false);
 
-#ifdef Slicer_HAVE_QT5
   q->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
   q->header()->setSectionResizeMode(0, QHeaderView::Stretch);
-#else
-  q->header()->setResizeMode(QHeaderView::ResizeToContents);
-  q->header()->setResizeMode(0, QHeaderView::Stretch);
-#endif
 
   //this->SortFilterModel->setSourceModel(this->SceneModel);
   //q->qMRMLTreeView::setModel(this->SortFilterModel);

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayBasicWidget.h
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayBasicWidget.h
@@ -7,7 +7,7 @@
 // CTK includes
 #include <ctkVTKObject.h>
 
-// SlicerQt includes
+// Slicer includes
 #include <qSlicerWidget.h>
 
 // qMRML includes

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayGlyphWidget.h
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayGlyphWidget.h
@@ -7,7 +7,7 @@
 // CTK includes
 #include <ctkVTKObject.h>
 
-// SlicerQt includes
+// Slicer includes
 #include <qSlicerWidget.h>
 
 // qMRML includes

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.h
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.h
@@ -20,7 +20,7 @@
 // CTK includes
 #include <ctkPimpl.h>
 
-// SlicerQt includes
+// Slicer includes
 #include "qSlicerAbstractModuleWidget.h"
 #include "qSlicerTractographyDisplayModuleWidgetsExport.h"
 

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayWidget.h
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayWidget.h
@@ -7,7 +7,7 @@
 // CTK includes
 #include <ctkVTKObject.h>
 
-// SlicerQt includes
+// Slicer includes
 #include <qSlicerWidget.h>
 
 // qMRML includes

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.h
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.h
@@ -7,7 +7,7 @@
 // CTK includes
 #include <ctkVTKObject.h>
 
-// SlicerQt includes
+// Slicer includes
 #include <qSlicerWidget.h>
 
 // qMRML includes

--- a/Modules/Loadable/TractographyDisplay/qSlicerFiberBundleReader.cxx
+++ b/Modules/Loadable/TractographyDisplay/qSlicerFiberBundleReader.cxx
@@ -21,7 +21,7 @@
 // Qt includes
 #include <QDir>
 
-// SlicerQt includes
+// Slicer includes
 #include "qSlicerFiberBundleReader.h"
 
 // Logic includes

--- a/Modules/Loadable/TractographyDisplay/qSlicerFiberBundleReader.h
+++ b/Modules/Loadable/TractographyDisplay/qSlicerFiberBundleReader.h
@@ -21,7 +21,7 @@
 #ifndef __qSlicerFiberBundleReader_h
 #define __qSlicerFiberBundleReader_h
 
-// SlicerQt includes
+// Slicer includes
 #include "qSlicerFileReader.h"
 class qSlicerFiberBundleReaderPrivate;
 

--- a/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.cxx
+++ b/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.cxx
@@ -42,13 +42,6 @@ VTK_MODULE_INIT(vtkTractographyDisplayMRMLDM)
 #endif
 
 //-----------------------------------------------------------------------------
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-// QT includes
-#include <QtPlugin>
-Q_EXPORT_PLUGIN2(qSlicerTractographyDisplayModule, qSlicerTractographyDisplayModule);
-#endif
-
-//-----------------------------------------------------------------------------
 qSlicerTractographyDisplayModule::
 qSlicerTractographyDisplayModule(QObject* _parent)
   : Superclass(_parent)

--- a/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.cxx
+++ b/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.cxx
@@ -36,10 +36,8 @@
 #include <vtkMRMLThreeDViewDisplayableManagerFactory.h>
 
 // DisplayableManager initialization
-#if Slicer_VERSION_MAJOR == 4 && Slicer_VERSION_MINOR >= 9
 #include <vtkAutoInit.h>
 VTK_MODULE_INIT(vtkTractographyDisplayMRMLDM)
-#endif
 
 //-----------------------------------------------------------------------------
 qSlicerTractographyDisplayModule::

--- a/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.cxx
+++ b/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.cxx
@@ -18,7 +18,7 @@
 
 ==============================================================================*/
 
-// SlicerQt includes
+// Slicer includes
 #include <qSlicerCoreApplication.h>
 #include <qSlicerCoreIOManager.h>
 #include <qSlicerNodeWriter.h>

--- a/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.h
+++ b/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.h
@@ -36,9 +36,7 @@ class Q_SLICER_QTMODULES_TRACTOGRAPHYDISPLAY_EXPORT qSlicerTractographyDisplayMo
   :public qSlicerLoadableModule
 {
   Q_OBJECT
-#ifdef Slicer_HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
-#endif
   Q_INTERFACES(qSlicerLoadableModule);
 public:
   typedef qSlicerLoadableModule Superclass;


### PR DESCRIPTION
Ensures the displayable manager is registered when the extension
is built against Slicer >=5. It removes the conditional check originally
introduced in 45eceb180 (Ensure displayable manager are registered with Slicer >= 4.9).

Runtime error fixed is the following:

```
  Generic Warning: In /path/to/Slicer-Release/VTK/Common/Core/vtkDebugLeaks.cxx, line 272
  Deleting unknown object: vtkMRMLTractographyDisplayDisplayableManager

  Warning: In /path/to/Slicer/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerFactory.cxx, line 136
  vtkMRMLThreeDViewDisplayableManagerFactory (0x55b6315a8dd0): RegisterDisplayableManager - vtkMRMLTractographyDisplayDisplayableManager is not a displayable manager. Failed to register
```