### PR TITLE
ENH: Switch ROI selection from Annotations to Markups #158

### DIFF
--- a/Modules/Loadable/InteractiveSeeding/CMakeLists.txt
+++ b/Modules/Loadable/InteractiveSeeding/CMakeLists.txt
@@ -37,7 +37,7 @@ set(MODULE_UI_SRCS
 set(MODULE_TARGET_LIBRARIES
   vtkDMRI
   vtkIntxSeedingLogic
-  vtkSlicerAnnotationsModuleMRML
+  vtkSlicerMarkupsModuleMRML
   )
 
 set(MODULE_RESOURCES

--- a/Modules/Loadable/InteractiveSeeding/Logic/CMakeLists.txt
+++ b/Modules/Loadable/InteractiveSeeding/Logic/CMakeLists.txt
@@ -18,7 +18,7 @@ set(${KIT}_SRCS
 set(${KIT}_TARGET_LIBRARIES
   vtkDMRI
   ${ITK_LIBRARIES}
-  vtkSlicerAnnotationsModuleMRML
+  vtkSlicerMarkupsModuleMRML
   vtkSlicerMarkupsModuleMRML
   vtkSlicerTractographyDisplayModuleMRML
   )

--- a/Modules/Loadable/InteractiveSeeding/Logic/vtkSlicerTractographyInteractiveSeedingLogic.cxx
+++ b/Modules/Loadable/InteractiveSeeding/Logic/vtkSlicerTractographyInteractiveSeedingLogic.cxx
@@ -341,7 +341,7 @@ void vtkSlicerTractographyInteractiveSeedingLogic::CreateTractsForOneSeed(vtkSee
     }
   else if (markupsFiducialNode && markupsFiducialNode->GetNumberOfControlPoints())
     {
-    int numberOfFiducials = markupsFiducialNode->GetNumberOfMarkups();
+    int numberOfFiducials = markupsFiducialNode->GetNumberOfControlPoints();
     for (int i = 0; i < numberOfFiducials; ++i)
       {
       if (!seedSelectedFiducials ||

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
@@ -30,7 +30,7 @@
 
 class vtkMRMLFiberBundleDisplayNode;
 class vtkExtractSelectedPolyDataIds;
-class vtkMRMLAnnotationNode;
+class vtkMRMLMarkupsNode;
 class vtkIdTypeArray;
 class vtkExtractPolyDataGeometry;
 class vtkPlanes;
@@ -102,16 +102,16 @@ public:
 
   ///
   /// Get annotation MRML object.
-  vtkMRMLAnnotationNode* GetAnnotationNode ( );
+  vtkMRMLMarkupsNode* GetMarkupsNode ( );
 
 
   ///
   /// Set the ID annotation node for interactive selection.
-  void SetAndObserveAnnotationNodeID ( const char *ID );
+  void SetAndObserveMarkupsNodeID ( const char *ID );
 
   ///
   /// Get ID of diffusion tensor display MRML object for fiber glyph.
-  vtkGetStringMacro(AnnotationNodeID);
+  vtkGetStringMacro(MarkupsNodeID);
 
   //--------------------------------------------------------------------------
   /// Interactive Selection Support
@@ -119,8 +119,8 @@ public:
 
   ///
   /// Enable or disable the selection with an annotation node
-  virtual void SetSelectWithAnnotation(bool);
-  vtkGetMacro(SelectWithAnnotation, bool);
+  virtual void SetSelectWithMarkups(bool);
+  vtkGetMacro(SelectWithMarkups, bool);
 
   enum SelectionModeEnum
   {
@@ -132,8 +132,8 @@ public:
 
   ///
   /// Set the mode (positive or negative) of the selection with the annotation node
-  vtkGetMacro(AnnotationSelectionMode, SelectionModeEnum);
-  virtual void SetAnnotationSelectionMode(SelectionModeEnum);
+  vtkGetMacro(MarkupsSelectionMode, SelectionModeEnum);
+  virtual void SetMarkupsSelectionMode(SelectionModeEnum);
 
   ///
   /// Reimplemented from internal reasons
@@ -206,13 +206,13 @@ protected:
 
   /// ALL MRML nodes
   bool EnableShuffleIDs;
-  bool SelectWithAnnotation;
-  SelectionModeEnum AnnotationSelectionMode;
+  bool SelectWithMarkups;
+  SelectionModeEnum MarkupsSelectionMode;
 
-  vtkMRMLAnnotationNode *AnnotationNode;
-  char *AnnotationNodeID;
+  vtkMRMLMarkupsNode *MarkupsNode;
+  char *MarkupsNodeID;
 
-  virtual void SetAnnotationNodeID(const char* id);
+  virtual void SetMarkupsNodeID(const char* id);
 
   // Pipeline filter objects
   vtkExtractPolyDataGeometry* ExtractFromROI;

--- a/Modules/Loadable/TractographyDisplay/MRMLDM/CMakeLists.txt
+++ b/Modules/Loadable/TractographyDisplay/MRMLDM/CMakeLists.txt
@@ -31,7 +31,7 @@ set(${KIT}_SRCS
 set(${KIT}_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
   ${MRML_LIBRARIES}
-  vtkSlicerAnnotationsModuleMRML
+  vtkSlicerMarkupsModuleMRML
   vtkSlicer${MODULE_NAME}ModuleLogic
   vtkSlicer${MODULE_NAME}ModuleMRML
   )

--- a/Modules/Loadable/TractographyDisplay/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/TractographyDisplay/Widgets/CMakeLists.txt
@@ -51,7 +51,7 @@ set(${KIT}_RESOURCES
 set(${KIT}_TARGET_LIBRARIES
   vtkSlicerTractographyDisplayModuleLogic
   ${MRML_LIBRARIES}
-  vtkSlicerAnnotationsModuleMRML
+  vtkSlicerMarkupsModuleMRML
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/TractographyDisplay/Widgets/Resources/UI/qSlicerTractographyEditorROIWidget.ui
+++ b/Modules/Loadable/TractographyDisplay/Widgets/Resources/UI/qSlicerTractographyEditorROIWidget.ui
@@ -34,7 +34,7 @@
      </property>
      <property name="nodeTypes">
       <stringlist>
-       <string>vtkMRMLAnnotationROINode</string>
+       <string>vtkMRMLMarkupsROINode</string>
       </stringlist>
      </property>
      <property name="showHidden">
@@ -82,16 +82,6 @@
        </widget>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QCheckBox" name="InteractiveROI">
-     <property name="text">
-      <string>Interactive ROI Updates</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
    <item row="2" column="1">

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.cxx
@@ -59,6 +59,13 @@ void qSlicerTractographyEditorROIWidgetPrivate::init()
 
   this->EnableFiberEdit->setToolTip(QString("Click in 3D view to focus\n s: toggle select/unselect individual fibers\n x: unselect all selected fibers\n d: delete selected fibers or an individual fiber, if none is selected"));
 
+#ifndef ENABLE_FIBER_EDIT
+  // This feature stopped working sometime during the evolution of Slicer 4/5.
+  // Rather than remove all the code, we hide it away with the idea that it
+  // can be re-enabled and debugged in the future if needed.
+  this->EnableFiberEdit->hide();
+#endif
+
   QObject::connect(this->ROIForFiberSelectionMRMLNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
                    q, SLOT(setMarkupsMRMLNodeForFiberSelection(vtkMRMLNode*)));
   QObject::connect(this->ROIForFiberSelectionMRMLNodeSelector, SIGNAL(nodeAddedByUser(vtkMRMLNode*)),

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.h
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyEditorROIWidget.h
@@ -32,8 +32,8 @@ public:
 public slots:
   void setFiberBundleNode(vtkMRMLNode *);
   void setFiberBundleNode(vtkMRMLFiberBundleNode*);
-  void setAnnotationMRMLNodeForFiberSelection(vtkMRMLNode*);
-  void setAnnotationROIMRMLNodeToFiberBundleEnvelope(vtkMRMLNode*);
+  void setMarkupsMRMLNodeForFiberSelection(vtkMRMLNode*);
+  void setMarkupsROIMRMLNodeToFiberBundleEnvelope(vtkMRMLNode*);
   void disableROISelection(bool);
   void positiveROISelection(bool);
   void negativeROISelection(bool);


### PR DESCRIPTION
Since Annotations are deprected since Slicer 5, the corresponding MarkupsROI code is used. See linked issue for more details.

With this change the ROI node no longer has an `InteractiveMode`, which had been used to enable/disable hot-update of ROI selection and there does not appear to be a replacement in the Markups infrastructure.  However when using ROI selection it is actually the same to just disable ROI selection while editing the ROI and then switch back to positive or negative selection mode when ROI edit is finished.  Since this accomplishes the same result the checkbox is removed to simplify the code and the interface.


Fixes #158