### PR TITLE
COMP: fix missing method link error

### DIFF
--- a/Modules/Loadable/InteractiveSeeding/Logic/CMakeLists.txt
+++ b/Modules/Loadable/InteractiveSeeding/Logic/CMakeLists.txt
@@ -19,7 +19,7 @@ set(${KIT}_TARGET_LIBRARIES
   vtkDMRI
   ${ITK_LIBRARIES}
   vtkSlicerMarkupsModuleMRML
-  vtkSlicerMarkupsModuleMRML
+  vtkSlicerAnnotationsModuleMRML
   vtkSlicerTractographyDisplayModuleMRML
   )
 

--- a/Modules/Loadable/TractographyDisplay/MRML/CMakeLists.txt
+++ b/Modules/Loadable/TractographyDisplay/MRML/CMakeLists.txt
@@ -28,9 +28,9 @@ set(${KIT}_TARGET_LIBRARIES
   vtkDMRI
   ${MRML_LIBRARIES}
   ${VTK_LIBRARIES}
-   vtkSlicerAnnotationsModuleMRML
-   vtkTeem
-   )
+  vtkSlicerMarkupsModuleMRML
+  vtkTeem
+  )
 
 #-----------------------------------------------------------------------------
 SlicerMacroBuildModuleMRML(


### PR DESCRIPTION
Follow on to https://github.com/SlicerDMRI/SlicerDMRI/commit/a2ca048a1896df5dcd43ecdffd191297a7ef25ac

Fixes #165