### PR TITLE
ENH: Use `SetVisibility2D` instead of `SetSliceIntersectionVisibility`

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Testing/Python/SlicerMRBTest.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/SlicerMRBTest.py
@@ -261,10 +261,10 @@ execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Pyt
       tubeDisplay = fiberNode.GetTubeDisplayNode()
       if tractName == whichTract:
         tubeDisplay.SetVisibility(1)
-        tubeDisplay.SetSliceIntersectionVisibility(1)
+        tubeDisplay.SetVisibility2D(1)
       else:
         tubeDisplay.SetVisibility(0)
-        tubeDisplay.SetSliceIntersectionVisibility(0)
+        tubeDisplay.SetVisibility2D(0)
 
   def storeSceneView(self,name,description=""):
     """  Store a scene view into the current scene.

--- a/Modules/Loadable/TractographyDisplay/Widgets/qMRMLSceneTractographyDisplayModel.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qMRMLSceneTractographyDisplayModel.cxx
@@ -379,7 +379,7 @@ updateVilibilityFromItem(QStandardItem* item, vtkMRMLNode* node, bool slice)
     {
     if (slice)
       {
-      displayNode->SetSliceIntersectionVisibility(visible);
+      displayNode->SetVisibility2D(visible);
       }
     else
       {

--- a/Modules/Loadable/TractographyDisplay/Widgets/qMRMLTractographyDisplayTreeView.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qMRMLTractographyDisplayTreeView.cxx
@@ -251,7 +251,7 @@ bool qMRMLTractographyDisplayTreeView::clickDecoration(const QModelIndex& index)
     {
     if (tubeDisplayNode)
       {
-      tubeDisplayNode->SetSliceIntersectionVisibility(tubeDisplayNode->GetSliceIntersectionVisibility() ? 0 : 1);
+      tubeDisplayNode->SetVisibility2D(tubeDisplayNode->GetSliceIntersectionVisibility() ? 0 : 1);
       res = true;
       }
   }

--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayBasicWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayBasicWidget.cxx
@@ -210,5 +210,5 @@ void qSlicerTractographyDisplayBasicWidget::
     return;
   vtkMRMLFiberBundleDisplayNode* dNode = d->FiberBundleNode->GetTubeDisplayNode();
   if(dNode)
-    dNode->SetSliceIntersectionVisibility(state > 0);
+    dNode->SetVisibility2D(state > 0);
 }


### PR DESCRIPTION
Use `SetVisibility2D` instead of `SetSliceIntersectionVisibility` to toggle tractography tubes' 2D slice intersection visibility.

Fixes:
```
[VTK] Warning:
In /work/Stable/Slicer-0/Libs/MRML/Core/vtkMRMLDisplayNode.cxx, line 996
[VTK] vtkMRMLFiberBundleTubeDisplayNode (0x73bd250):
SetSliceIntersectionVisibility method is deprecated, please use SetVisibility2D instead
```