### PR TITLE
ENH: Remove unnecessary stat serialization whitespaces around separator

### DIFF
--- a/Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx
+++ b/Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx
@@ -541,7 +541,7 @@ void printTable(std::ostream &ofs, bool printHeader,
       it2 = names.find(*agg_iter);
       if (it2 != names.end())
         {
-        ofs       << " " << SEPARATOR << " " << it2->second;
+        ofs << SEPARATOR << it2->second;
         }
       }
 
@@ -549,7 +549,7 @@ void printTable(std::ostream &ofs, bool printHeader,
       {
       if (std::find(aggregate_names.begin(), aggregate_names.end(), it2->first) == aggregate_names.end())
         {
-        ofs       << " " << SEPARATOR << " " << it2->second;
+        ofs << SEPARATOR << it2->second;
         }
       }
     ofs << std::endl;
@@ -581,7 +581,7 @@ void printTable(std::ostream &ofs, bool printHeader,
       it2 = names.find(*agg_iter);
       if (it2 != names.end())
         {
-        ofs << " " << SEPARATOR << " ";
+        ofs << SEPARATOR;
         it1 = it->second.find(*agg_iter);
         if (it1 != it->second.end())
           {
@@ -602,7 +602,7 @@ void printTable(std::ostream &ofs, bool printHeader,
       {
       if (std::find(aggregate_names.begin(), aggregate_names.end(), it2->first) == aggregate_names.end())
         {
-        ofs << " " << SEPARATOR << " ";
+        ofs << SEPARATOR;
 
         it1 = it->second.find(it2->second);
         if (it1 != it->second.end() &&


### PR DESCRIPTION
Remove unnecessary whitespaces around separator in fiber measurement stat printing and serialization. These whitespaces make it such that:
- The column names have some unnecessary/unexpected/undesired head and tail whitespaces, which makes it such that to call a column programmatically we need to do e.g. `[" Num_Fibers "]` instead of the expected `["Num_Fibers"]`.
- Numerical data are considered as strings or objects, and not as scalars.

So removing such whitespaces at the time of writing the data to a CSV file becomes necessary to ease automation/object manipulation downstream.