### PR TITLE
BUG: add fiber storage node to the scene

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.cxx
+++ b/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.cxx
@@ -129,6 +129,7 @@ vtkMRMLFiberBundleNode* vtkSlicerFiberBundleLogic::AddFiberBundle (const char* f
     fiberBundleNode->SetName(volumeName.c_str());
 
     fiberBundleNode->SetScene(this->GetMRMLScene());
+    this->GetMRMLScene()->AddNode(storageNode);
     fiberBundleNode->SetAndObserveStorageNodeID(storageNode->GetID());
     this->GetMRMLScene()->AddNode(fiberBundleNode);
     fiberBundleNode->CreateDefaultDisplayNodes();


### PR DESCRIPTION
The storage node was used but not saved in the scene, making the behavior inconsistent with corresponding method in the models superclass.

See discussion here: https://discourse.slicer.org/t/path-of-the-loaded-fiber-bundle/30524