### PR TITLE
DOC: Increase consistency in SlicerDMRI citation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ CDash for extensions: [http://slicer.cdash.org](http://slicer.cdash.org/index.ph
 
 For publications please include this text (modifying the initial part to describe your SlicerDMRI use case):
 
-"We performed diffusion MRI and/or tractography analysis and/or visualization in 3D Slicer (http://www.slicer.org) via the SlicerDMRI project (https://github.com/SlicerDMRI), funded by NIH U01 CA199459."
+"We performed diffusion MRI and/or tractography analysis and/or visualization in 3D Slicer (https://www.slicer.org) via the SlicerDMRI project (https://dmri.slicer.org/), funded by NIH U01 CA199459."


### PR DESCRIPTION
Increase consistency in SlicerDMRI citation message:
- Prefer using https over http for web addresses when available.
- Use the website to refer to SlicerDMRI instead of the source code repository.