### PR TITLE
COMP: Simplify TractographyDisplay Python tests removing obsolete workaround

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/CMakeLists.txt
@@ -8,16 +8,8 @@ slicerMacroBuildScriptedModule(
   RESOURCES ""
   )
 
-# work around runner bug https://issues.slicer.org/view.php?id=4242
-set(DMRI_UNITTEST_LIB_PATHS "--additional-module-paths;${CMAKE_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}/Release;${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}/Release;${CMAKE_BINARY_DIR}/${Slicer_CLIMODULES_LIB_DIR}/Release")
-
-slicer_add_python_unittest(SCRIPT NsgPlanTracto.py
-	SLICER_ARGS ${DMRI_UNITTEST_LIB_PATHS})
-slicer_add_python_unittest(SCRIPT DTINotReproducibleIssue3977.py
-	SLICER_ARGS ${DMRI_UNITTEST_LIB_PATHS})
-slicer_add_python_unittest(SCRIPT fiber_visibility_crash2438.py
-	SLICER_ARGS ${DMRI_UNITTEST_LIB_PATHS})
-slicer_add_python_unittest(SCRIPT test_tractography_display.py
-	SLICER_ARGS ${DMRI_UNITTEST_LIB_PATHS})
-slicer_add_python_unittest(SCRIPT SlicerMRBTest.py
-	SLICER_ARGS ${DMRI_UNITTEST_LIB_PATHS})
+slicer_add_python_unittest(SCRIPT NsgPlanTracto.py)
+slicer_add_python_unittest(SCRIPT DTINotReproducibleIssue3977.py)
+slicer_add_python_unittest(SCRIPT fiber_visibility_crash2438.py)
+slicer_add_python_unittest(SCRIPT test_tractography_display.py)
+slicer_add_python_unittest(SCRIPT SlicerMRBTest.py)


### PR DESCRIPTION
This commit removes workaround for issue Slicer/Slicer#4242 originally introduced in 2e5fb00d3 (COMP: work around python unittest runner bug for windows tests) and obsoleted following these Slicer commits:
* Slicer/Slicer@f07a6c3d7 (BUG: Teach 'slicer_add_python_unittest' to add module search paths)
* Slicer/Slicer@bd6a48784 (COMP: SlicerMacroPythonTesting: Fix typo in CMake variable)