### PR TITLE
COMP: Fix miscellaneous warnings

### DIFF
--- a/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx
+++ b/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx
@@ -501,7 +501,7 @@ int vtkTeemEstimateDiffusionTensor::SetGradientsToContext(tenEstimateContext *te
   double *data = (double *) this->RescaledDiffusionGradients->GetVoidPointer(0);
   if(nrrdWrap_nva(ngrad ,data,type,2,size)) {
     biffAdd(NRRD, err);
-    sprintf(err,"%s:",this->GetClassName());
+    snprintf(err, sizeof(err), "%s:",this->GetClassName());
     return 1;
   }
 
@@ -509,7 +509,7 @@ int vtkTeemEstimateDiffusionTensor::SetGradientsToContext(tenEstimateContext *te
 
   if (tenBMatrixCalc(nbmat,ngrad) ) {
     biffAdd(NRRD, err);
-    sprintf(err,"%s:",this->GetClassName());
+    snprintf(err, sizeof(err), "%s:",this->GetClassName());
     return 1;
   }
 

--- a/Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx
+++ b/Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx
@@ -1021,7 +1021,7 @@ int main( int argc, char * argv[] )
       {
       vtkNew<vtkPolyDataReader> reader;
       std::string fileName = fileNamesVTK->GetValue(i);
-      reader->SetFileName(fileNamesVTK->GetValue(i));
+      reader->SetFileName(fileNamesVTK->GetValue(i).c_str());
       reader->Update();
 
       vtkSmartPointer<vtkPolyData> data = reader->GetOutput();

--- a/Modules/Loadable/TractIO/TractIOCLI/VTK_to_DICOMTract.cxx
+++ b/Modules/Loadable/TractIO/TractIOCLI/VTK_to_DICOMTract.cxx
@@ -460,7 +460,7 @@ int add_tracts(SP<TrcTractographyResults> dcmtract,
   algorithmId.setAlgorithmSource("");
 
   char buf_label[100];
-  sprintf(buf_label, "%s", info.label.c_str());
+  snprintf(buf_label, sizeof(buf_label), "%s", info.label.c_str());
 
   TrcTrackSet *trackset = NULL;
   result = dcmtract->addTrackSet(

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
@@ -29,7 +29,7 @@ Version:   $Revision: 1.3 $
 #include <vtkAlgorithmOutput.h>
 #include <vtkCommand.h>
 #include <vtkExtractPolyDataGeometry.h>
-#include <vtkExtractSelectedPolyDataIds.h>
+#include <vtkExtractSelection.h>
 #include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
 #include <vtkNew.h>
@@ -104,7 +104,7 @@ vtkMRMLFiberBundleNode::vtkMRMLFiberBundleNode() :
   MarkupsNode(NULL),
   MarkupsNodeID(NULL),
   ExtractFromROI(vtkExtractPolyDataGeometry::New()),
-  ExtractSubsample(vtkExtractSelectedPolyDataIds::New()),
+  ExtractSubsample(vtkExtractSelection::New()),
   Planes(vtkPlanes::New()),
   LocalPassThrough(vtkPassThrough::New())
 {


### PR DESCRIPTION
- COMP: Prefer `snprintf` to avoid buffer overruns
- COMP: Call explicitly `.c_str()` to get a `const char*`
- COMP: Prefer using `vtkExtractSelection`