### PR TITLE
COMP: Call explicitly `.c_str()` to get a `const char*`

### DIFF
--- a/Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx
+++ b/Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx
@@ -1021,7 +1021,7 @@ int main( int argc, char * argv[] )
       {
       vtkNew<vtkPolyDataReader> reader;
       std::string fileName = fileNamesVTK->GetValue(i);
-      reader->SetFileName(fileNamesVTK->GetValue(i));
+      reader->SetFileName(fileNamesVTK->GetValue(i).c_str());
       reader->Update();
 
       vtkSmartPointer<vtkPolyData> data = reader->GetOutput();


### PR DESCRIPTION
Call explicitly `.c_str()` to get a `const char*`, instead of relying on the `operator const char *()` deprecated operator.

Fixes:
```
Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx:1024:27:
warning: 'operator const char *' is deprecated:
Call `.c_str()` explicitly [-Wdeprecated-declarations]

      reader->SetFileName(fileNamesVTK->GetValue(i));
                          ^
```

Raised for example in:
https://slicer.cdash.org/viewBuildError.php?type=1&buildid=3190094