### PR TITLE
COMP: Prefer using `vtkExtractSelection`

### DIFF
--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx
@@ -29,7 +29,7 @@ Version:   $Revision: 1.3 $
 #include <vtkAlgorithmOutput.h>
 #include <vtkCommand.h>
 #include <vtkExtractPolyDataGeometry.h>
-#include <vtkExtractSelectedPolyDataIds.h>
+#include <vtkExtractSelection.h>
 #include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
 #include <vtkNew.h>
@@ -104,7 +104,7 @@ vtkMRMLFiberBundleNode::vtkMRMLFiberBundleNode() :
   MarkupsNode(NULL),
   MarkupsNodeID(NULL),
   ExtractFromROI(vtkExtractPolyDataGeometry::New()),
-  ExtractSubsample(vtkExtractSelectedPolyDataIds::New()),
+  ExtractSubsample(vtkExtractSelection::New()),
   Planes(vtkPlanes::New()),
   LocalPassThrough(vtkPassThrough::New())
 {

--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
@@ -29,7 +29,7 @@
 #include "vtkSlicerTractographyDisplayModuleMRMLExport.h"
 
 class vtkMRMLFiberBundleDisplayNode;
-class vtkExtractSelectedPolyDataIds;
+class vtkExtractSelection;
 class vtkMRMLMarkupsNode;
 class vtkIdTypeArray;
 class vtkExtractPolyDataGeometry;
@@ -219,7 +219,7 @@ protected:
 
 private:
   // Pipeline filter objects
-  vtkExtractSelectedPolyDataIds* ExtractSubsample;
+  vtkExtractSelection* ExtractSubsample;
   vtkPlanes *Planes;
   vtkPassThrough* LocalPassThrough;
 

--- a/Modules/Scripted/FiberBundleToLabelMap/FiberBundleToLabelMap.py
+++ b/Modules/Scripted/FiberBundleToLabelMap/FiberBundleToLabelMap.py
@@ -182,7 +182,7 @@ class FiberBundleToLabelMapLogic(object):
     selectionNode.SetFieldType(vtk.vtkSelectionNode.CELL)
     selectionNode.SetContentType(vtk.vtkSelectionNode.INDICES)
 
-    extractor = vtk.vtkExtractSelectedPolyDataIds()
+    extractor = vtk.vtkExtractSelection()
     extractor.SetInputData(0, polyData)
 
     resampler = vtk.vtkPolyDataPointSampler()


### PR DESCRIPTION
Prefer using `vtkExtractSelection` over the deprecated `vtkExtractSelectedPolyDataIds`.

Fixes:
```
Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.cxx:107:49:
warning: 'vtkExtractSelectedPolyDataIds' is deprecated:
Use vtkExtractSelection instead of vtkExtractSelectedPolyDataIds.
[-Wdeprecated-declarations]

  ExtractSubsample(vtkExtractSelectedPolyDataIds::New()),
                                                ^
```

Raised for example in:
https://slicer.cdash.org/viewBuildError.php?type=1&buildid=3190094

Documentation
https://vtk.org/doc/nightly/html/classvtkExtractSelectedPolyDataIds.html#details