### PR TITLE
COMP: Prefer `snprintf` to avoid buffer overruns

### DIFF
--- a/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx
+++ b/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx
@@ -501,7 +501,7 @@ int vtkTeemEstimateDiffusionTensor::SetGradientsToContext(tenEstimateContext *te
   double *data = (double *) this->RescaledDiffusionGradients->GetVoidPointer(0);
   if(nrrdWrap_nva(ngrad ,data,type,2,size)) {
     biffAdd(NRRD, err);
-    sprintf(err,"%s:",this->GetClassName());
+    snprintf(err, sizeof(err), "%s:",this->GetClassName());
     return 1;
   }
 
@@ -509,7 +509,7 @@ int vtkTeemEstimateDiffusionTensor::SetGradientsToContext(tenEstimateContext *te
 
   if (tenBMatrixCalc(nbmat,ngrad) ) {
     biffAdd(NRRD, err);
-    sprintf(err,"%s:",this->GetClassName());
+    snprintf(err, sizeof(err), "%s:",this->GetClassName());
     return 1;
   }
 

--- a/Modules/Loadable/TractIO/TractIOCLI/VTK_to_DICOMTract.cxx
+++ b/Modules/Loadable/TractIO/TractIOCLI/VTK_to_DICOMTract.cxx
@@ -460,7 +460,7 @@ int add_tracts(SP<TrcTractographyResults> dcmtract,
   algorithmId.setAlgorithmSource("");
 
   char buf_label[100];
-  sprintf(buf_label, "%s", info.label.c_str());
+  snprintf(buf_label, sizeof(buf_label), "%s", info.label.c_str());
 
   TrcTrackSet *trackset = NULL;
   result = dcmtract->addTrackSet(


### PR DESCRIPTION
Prefer `snprintf` over `sprintf` to avoid buffer overruns.

Fixes:
```
Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx:504:5:
warning: 'sprintf' is deprecated:
This function is provided for compatibility reasons only.
Due to security concerns inherent in the design of sprintf(3),
it is highly recommended that you use snprintf(3) instead.
[-Wdeprecated-declarations]
```

and similar warnings.

Raised for example in:
https://slicer.cdash.org/viewBuildError.php?type=1&buildid=3190094