### PR TITLE
COMP: Fix `sizeof` argument in `snprintf` call

### DIFF
--- a/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx
+++ b/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx
@@ -501,7 +501,7 @@ int vtkTeemEstimateDiffusionTensor::SetGradientsToContext(tenEstimateContext *te
   double *data = (double *) this->RescaledDiffusionGradients->GetVoidPointer(0);
   if(nrrdWrap_nva(ngrad ,data,type,2,size)) {
     biffAdd(NRRD, err);
-    snprintf(err, sizeof(err), "%s:",this->GetClassName());
+    snprintf(err, sizeof(*err), "%s:",this->GetClassName());
     return 1;
   }
 
@@ -509,7 +509,7 @@ int vtkTeemEstimateDiffusionTensor::SetGradientsToContext(tenEstimateContext *te
 
   if (tenBMatrixCalc(nbmat,ngrad) ) {
     biffAdd(NRRD, err);
-    snprintf(err, sizeof(err), "%s:",this->GetClassName());
+    snprintf(err, sizeof(*err), "%s:",this->GetClassName());
     return 1;
   }
 


### PR DESCRIPTION
Fix `sizeof` argument in `snprintf` call: dereference pointer to buffer.

Fixes:
```
Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx:504:19:
warning: argument to ‘sizeof’ in ‘int snprintf(char*, size_t, const char*, ...)’
call is the same expression as the destination;
did you mean to provide an explicit length? [-Wsizeof-pointer-memaccess]
  504 |     snprintf(err, sizeof(err), "%s:",this->GetClassName());
      |                   ^~~~~~~~~~~
```

and similar warnings.

Raised for example at:
https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/6679353771/job/18151381270#step:7:246