### PR TITLE
STYLE: Remove deprecated Python `import` statements

### DIFF
--- a/DMRIModuleTemplates/Tractography_Scripted/TemplateKey.py
+++ b/DMRIModuleTemplates/Tractography_Scripted/TemplateKey.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import unittest, os, logging, warnings
 
 

--- a/Modules/CLI/ExtractDWIShells/ExtractDWIShells.py
+++ b/Modules/CLI/ExtractDWIShells/ExtractDWIShells.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python-real
 
-from __future__ import print_function
-from __future__ import division
 import sys
 import argparse
 

--- a/Modules/Loadable/TractographyDisplay/Testing/Python/NsgPlanTracto.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/NsgPlanTracto.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import time
 import unittest

--- a/Modules/Loadable/TractographyDisplay/Testing/Python/SlicerMRBTest.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/SlicerMRBTest.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-
 import os
 import unittest
 import vtk

--- a/Modules/Loadable/TractographyDisplay/Testing/Python/fiber_visibility_crash2438.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/fiber_visibility_crash2438.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Modules/Loadable/TractographyDisplay/Testing/Python/test_tractography_display.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/test_tractography_display.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Modules/Scripted/DMRIPlugins/DICOMDiffusionVolumePlugin.py
+++ b/Modules/Scripted/DMRIPlugins/DICOMDiffusionVolumePlugin.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk, qt, ctk, slicer
 from DICOMLib import DICOMPlugin

--- a/Modules/Scripted/FiberBundleToLabelMap/FiberBundleToLabelMap.py
+++ b/Modules/Scripted/FiberBundleToLabelMap/FiberBundleToLabelMap.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 import unittest

--- a/Modules/Scripted/TractographyDownsample/TractographyDownsample.py
+++ b/Modules/Scripted/TractographyDownsample/TractographyDownsample.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import glob
 import os
 import sys


### PR DESCRIPTION
Remove deprecated Python `import` statements: the statements:
```
from __future__ import print_function
from __future__ import division
```

are vestiges of code that was intended to support both Python 2 and Python 3. All Python 2 versions have reached their EOL since a few years now, so these `import`s are no longer required on any sensible Python version.