### PR TITLE
STYLE: Change `python-real` in shebang to commonplace `python`

### DIFF
--- a/Modules/CLI/ExtractDWIShells/ExtractDWIShells.py
+++ b/Modules/CLI/ExtractDWIShells/ExtractDWIShells.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python-real
+#!/usr/bin/env python
 
 from __future__ import print_function
 from __future__ import division


### PR DESCRIPTION
Change `python-real` in shebang to the commonplace `python`.