### PR TITLE
BUG: Fix DWI shell extraction module import sorting

### DIFF
--- a/Modules/CLI/ExtractDWIShells/ExtractDWIShells.py
+++ b/Modules/CLI/ExtractDWIShells/ExtractDWIShells.py
@@ -5,9 +5,8 @@ from __future__ import division
 import sys
 import argparse
 
-import slicer, slicer.util, mrml
+import vtk, slicer, slicer.util, mrml
 import numpy as np
-import vtk
 from vtk.util import numpy_support
 
 if sys.version_info[0] == 2:


### PR DESCRIPTION
Fix DWI shell extraction module import sorting: sort the imported packages following the class hierarchy and library dependencies.

Fixes:
```
loading:  SlicerDMRI/SlicerDMRI/Testdata/3x3x3_13_b1000_b3000.nrrd
Traceback (most recent call last):
  File "SlicerDMRI-build/inner-build/lib/Slicer-5.5/cli-modules/ExtractDWIShells.py",
  line 207, in <module>
    main()
  File "SlicerDMRI-build/inner-build/lib/Slicer-5.5/cli-modules/ExtractDWIShells.py",
  line 127, in main
    sn.ReadData(node_in)
TypeError: ReadData argument 1: method requires a VTK object
```

raised for example at:
https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/6722459285/job/18270424711?pr=191#step:8:2631

Related discussion:
https://github.com/Slicer/Slicer/issues/6484