### PR TITLE
BUG: Fix data download URLs and Slicer display message call

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Testing/Python/DTINotReproducibleIssue3977.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/DTINotReproducibleIssue3977.py
@@ -76,7 +76,7 @@ class DTINotReproducibleIssue3977Logic(ScriptedLoadableModuleLogic):
 
     # Compute the DTI output volume using the "DWI to DTI estimation" CLI module
     module = slicer.modules.dwitodtiestimation
-    self.delayDisplay(module.title)
+    slicer.util.delayDisplay(module.title)
     logging.info('"%s" started' % module.title)
     cliParams = {
       'inputVolume': inputVolume.GetID(),
@@ -91,7 +91,7 @@ class DTINotReproducibleIssue3977Logic(ScriptedLoadableModuleLogic):
 
     # Compute FA output volume using "Diffusion Tensor Scalar Measurements" CLI module
     module = slicer.modules.diffusiontensorscalarmeasurements
-    self.delayDisplay(module.title)
+    slicer.util.delayDisplay(module.title)
     logging.info('"%s" started' % module.title)
     cliParams = {
       'inputVolume': dtiVolume.GetID(),
@@ -141,7 +141,9 @@ class DTINotReproducibleIssue3977Test(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       nodeNames=(None, 'dwi'),
       fileNames=('dwi.raw.gz', 'dwi.nhdr'),
-      uris=('http://slicer.kitware.com/midas3/download/item/10304', 'http://slicer.kitware.com/midas3/download/item/10303'))
+      uris=(
+        'https://github.com/Slicer/SlicerTestingData/releases/download/SHA256/cf03fd53583dc05120d3314d0a82bdf5946799b1f72f2a7f08963f3fd24ca692',
+        'https://github.com/Slicer/SlicerTestingData/releases/download/SHA256/7666d83bc205382e418444ea60ab7df6dba6a0bd684933df8809da6b476b0fed'))
     self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="dwi")


### PR DESCRIPTION
Fix data download URLs and Slicer display message call in test:
- The Slicer testing data was moved from kitware midas hosting to GitHub repositories. Related thread: https://github.com/Slicer/Slicer/pull/4785
-  Use the `slicer.util` module to be able to call the `delayDisplay` method: the testing class `DTINotReproducibleIssue3977Logic` inherits from `ScriptedLoadableModuleLogic`, which does not have a parent class, and thus does not inherit the `delayDisplay` (as opposed to classes that inherit from `ScriptedLoadableModuleTest`.

Fixes:
```
   File "SlicerDMRI/Modules/Loadable/TractographyDisplay/Testing/Python/DTINotReproducibleIssue3977.py",
line 147, in test_DTINotReproducibleIssue39771
     volumeNode = slicer.util.getNode(pattern="dwi")
   File "SlicerDMRI/Slicer-build/Slicer-build/bin/Python/slicer/util.py",
line 1517, in getNode
     raise MRMLNodeNotFoundException("could not find nodes in the scene by name or id '%s'" % (pattern if (isinstance(pattern, str)) else ""))
 slicer.util.MRMLNodeNotFoundException: could not find nodes in the scene by name or id 'dwi'
```

raised for exampled at:
https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/6722459285/job/18270424711?pr=191#step:8:1317

and
```
   File "SlicerDMRI/Modules/Loadable/TractographyDisplay/Testing/Python/DTINotReproducibleIssue3977.py",
line 155, in test_DTINotReproducibleIssue39771
     (outputBaseline, outputFA) = logic.computeFA(volumeNode)
   File "SlicerDMRI/Modules/Loadable/TractographyDisplay/Testing/Python/DTINotReproducibleIssue3977.py",
line 79, in computeFA
     self.delayDisplay(module.title)
 AttributeError: 'DTINotReproducibleIssue3977Logic' object has no attribute 'delayDisplay'
```