### PR TITLE
STYLE: Use `toStdString().c_str()` instead of `toLatin1()` for `char*`

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayWidget.cxx
@@ -280,7 +280,7 @@ void qSlicerTractographyDisplayWidget::setActiveTensorName(const QString& arrayN
     {
     return;
     }
-  d->FiberBundleDisplayNode->SetActiveTensorName(arrayName.toLatin1());
+  d->FiberBundleDisplayNode->SetActiveTensorName(arrayName.toStdString().c_str());
 }
 
 //------------------------------------------------------------------------------
@@ -386,7 +386,7 @@ void qSlicerTractographyDisplayWidget::onColorByScalarChanged(int scalarIndex)
     }
 
   QString activeScalarName = d->ColorByScalarComboBox->itemText(scalarIndex);
-  d->FiberBundleDisplayNode->SetActiveScalarName(activeScalarName.toLatin1());
+  d->FiberBundleDisplayNode->SetActiveScalarName(activeScalarName.toStdString().c_str());
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/TractographyDisplay/qSlicerFiberBundleReader.cxx
+++ b/Modules/Loadable/TractographyDisplay/qSlicerFiberBundleReader.cxx
@@ -115,7 +115,7 @@ bool qSlicerFiberBundleReader::load(const IOProperties& properties)
       // suffix should be of style: "*.png"
       foreach(const QString& fileName, QDir(fileName).entryList(suffixList))
         {
-        vtkMRMLFiberBundleNode* node = d->FiberBundleLogic->AddFiberBundle(fileName.toLatin1());
+        vtkMRMLFiberBundleNode* node = d->FiberBundleLogic->AddFiberBundle(fileName.toStdString().c_str());
         if (node)
           {
           nodeIDs << node->GetID();
@@ -131,7 +131,7 @@ bool qSlicerFiberBundleReader::load(const IOProperties& properties)
       name = properties["name"].toString();
       }
 
-    vtkMRMLFiberBundleNode* node = d->FiberBundleLogic->AddFiberBundle(fileName.toLatin1(), name.toLatin1());
+    vtkMRMLFiberBundleNode* node = d->FiberBundleLogic->AddFiberBundle(fileName.toStdString().c_str(), name.toStdString().c_str());
     if (node)
       {
       nodeIDs << node->GetID();


### PR DESCRIPTION
Use `toStdString().c_str()` instead of `toLatin1()` to get a `const char*`.

Documentation:
https://doc.qt.io/qt-5/qstring.html#toStdString
https://doc.qt.io/qt-5/qstring.html#toLatin1