### PR TITLE
COMP: Use SetNthControlPointPosition instead of SetNthFiducialPosition

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Testing/Python/NsgPlanTracto.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/NsgPlanTracto.py
@@ -386,7 +386,7 @@ class NeurosurgicalPlanningTutorialTractographySelfTestLogic(object):
     for y in range(-20, 100, 5):
       msg = "Moving the fiducial to y = " + str(y)
       self.delayDisplay(msg,250)
-      fidNode.SetNthFiducialPosition(0, r, y, s)
+      fidNode.SetNthControlPointPosition(0, r, y, s)
 
     self.takeScreenshot('NeurosurgicalPlanning-TIS-Moved','Moved fiducial and did Tractography Interactive Seeding',-1)
     


### PR DESCRIPTION
Use `vtkMRMLMarkupsFiducialNode::SetNthControlPointPosition` instead of `vtkMRMLMarkupsFiducialNode::SetNthFiducialPosition`.

Fixes:
```
Warning: In vtkMRMLMarkupsFiducialNode.h, line 132
vtkMRMLMarkupsFiducialNode (0x557af863f8f0):
vtkMRMLMarkupsFiducialNode::SetNthFiducialPosition method is deprecated,
please use SetNthControlPointPosition instead
```

raised when running the `py_NsgPlanTracto` test.

The method was deprecated on Nov 28, 2021 through the Slicer commit: https://github.com/Slicer/Slicer/commit/73867d1c432842ee768ffb7693a4993070f5ff3c