### PR TITLE
ENH: Fix memory leaks

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayModuleWidget.cxx
@@ -18,6 +18,8 @@
 // CTK includes
 //#include <ctkModelTester.h>
 
+#include "vtkCollection.h"
+
 #include "qSlicerTractographyDisplayModuleWidget.h"
 #include "ui_qSlicerTractographyDisplayModuleWidget.h"
 #include "qMRMLSceneTractographyDisplayModel.h"
@@ -194,13 +196,13 @@ void qSlicerTractographyDisplayModuleWidget::setPercentageOfFibersShown(double p
 }
 void qSlicerTractographyDisplayModuleWidget::setSolidTubeColor(bool solid)
 {
-  std::vector<vtkMRMLNode *> nodes;
-  this->mrmlScene()->GetNodesByClass("vtkMRMLFiberBundleTubeDisplayNode", nodes);
+  vtkSmartPointer<vtkCollection> nodes = vtkSmartPointer<vtkCollection>::Take(
+    this->mrmlScene()->GetNodesByClass("vtkMRMLFiberBundleTubeDisplayNode"));
 
   vtkMRMLFiberBundleTubeDisplayNode *node = 0;
-  for (unsigned int i=0; i<nodes.size(); i++)
+  for (int i=0; i<nodes->GetNumberOfItems(); i++)
     {
-    node = vtkMRMLFiberBundleTubeDisplayNode::SafeDownCast(nodes[i]);
+    node = vtkMRMLFiberBundleTubeDisplayNode::SafeDownCast(nodes->GetItemAsObject(i));
     if (solid)
       {
       node->SetColorMode(vtkMRMLFiberBundleDisplayNode::colorModeSolid);

--- a/Modules/Scripted/TractographyDownsample/TractographyDownsample.py
+++ b/Modules/Scripted/TractographyDownsample/TractographyDownsample.py
@@ -597,6 +597,8 @@ logic.runBatchOnPaths(sourceFiberPaths, sourceDirectory, destinationDirectory, p
       self.run(node, node, parameters, advanced=1)
     logging.info('ADVANCED Processing completed')
 
+    nodeCollection.UnRegister(None)
+
     return True
 
 class TractographyDownsampleTest(ScriptedLoadableModuleTest):


### PR DESCRIPTION
Fix memory leaks reported by the
`qSlicerDICOM2FullBrainTractographyModuleGenericTest` test.

Use `vtkCollection` to store lists of objects instead of using raw smart pointers in the C++ code.

Unregister the object at issue in the Python code.

Fixes:
```
49: OK
49: vtkDebugLeaks has detected LEAKS!
49: Class "vtkMRMLMultiVolumeRenderingDisplayNode" has 1 instance still around.
49: Class "vtkMRMLGPURayCastVolumeRenderingDisplayNode" has 1 instance still around.
49: Class "vtkMRMLCPURayCastVolumeRenderingDisplayNode" has 1 instance still around.
49: Class "vtkMRMLShaderPropertyNode" has 1 instance still around.
49: Class "vtkOpenGLShaderProperty" has 1 instance still around.
49: Class "vtkMRMLVolumePropertyStorageNode" has 1 instance still around.
(...)
```

Documentation:
https://slicer.readthedocs.io/en/latest/developer_guide/advanced_topics.html#factory-methods