### PR TITLE
COMP: Fix `vtkHyperPoint` implicit declaration warning

### DIFF
--- a/Libs/vtkDMRI/vtkHyperPointandArray.h
+++ b/Libs/vtkDMRI/vtkHyperPointandArray.h
@@ -28,6 +28,7 @@
 class vtkDMRI_EXPORT vtkHyperPoint { //;prevent man page generation
 public:
     vtkHyperPoint(); /// method sets up storage
+    vtkHyperPoint(const vtkHyperPoint &) = default;
     vtkHyperPoint &operator=(const vtkHyperPoint& hp); //for resizing
 
     double   X[3];    /// position


### PR DESCRIPTION
Fix `vtkHyperPoint` implicit declaration warning: declare the copy constructor.

Fixes:
```
[50/263] Building CXX object Libs/vtkDMRI/CMakeFiles/vtkDMRIPython.dir/vtkHyperPointandArrayPython.cxx.o
SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkHyperPointandArrayPython.cxx:
 In function ‘PyObject* PyvtkHyperPoint_vtkHyperPoint_s2(PyObject*, PyObject*)’:
SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkHyperPointandArrayPython.cxx:53:49:
 warning: implicitly-declared ‘constexpr vtkHyperPoint::vtkHyperPoint(const vtkHyperPoint&)’ is deprecated [-Wdeprecated-copy]
   53 |     vtkHyperPoint *op = new vtkHyperPoint(*temp0);
      |                                                 ^
In file included from SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkHyperPointandArrayPython.cxx:10:
SlicerDMRI/Libs/vtkDMRI/vtkHyperPointandArray.h:31:20: note:
 because ‘vtkHyperPoint’ has user-provided ‘vtkHyperPoint& vtkHyperPoint::operator=(const vtkHyperPoint&)’
   31 |     vtkHyperPoint &operator=(const vtkHyperPoint& hp); //for resizing
      |                    ^~~~~~~~
SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkHyperPointandArrayPython.cxx:
 In function ‘void* PyvtkHyperPoint_CCopy(const void*)’:
SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkHyperPointandArrayPython.cxx:180:69:
 warning: implicitly-declared ‘constexpr vtkHyperPoint::vtkHyperPoint(const vtkHyperPoint&)’ is deprecated [-Wdeprecated-copy]
  180 |     return new vtkHyperPoint(*static_cast<const vtkHyperPoint*>(obj));
      |                                                                     ^
In file included from SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkHyperPointandArrayPython.cxx:10:
SlicerDMRI/SlicerDMRI/Libs/vtkDMRI/vtkHyperPointandArray.h:31:20:
 note: because ‘vtkHyperPoint’ has user-provided ‘vtkHyperPoint& vtkHyperPoint::operator=(const vtkHyperPoint&)’
   31 |     vtkHyperPoint &operator=(const vtkHyperPoint& hp); //for resizing
```

raised for example at:
https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/6686457985/job/18165832119#step:7:288