### PR TITLE
COMP: Fix `vtkTractographyPoint` implicit declaration warning

### DIFF
--- a/Libs/vtkDMRI/vtkTractographyPointAndArray.h
+++ b/Libs/vtkDMRI/vtkTractographyPointAndArray.h
@@ -27,6 +27,7 @@
 class vtkDMRI_EXPORT vtkTractographyPoint { //;prevent man page generation
 public:
     vtkTractographyPoint(); /// method sets up storage
+    vtkTractographyPoint(const vtkTractographyPoint &) = default;
     vtkTractographyPoint &operator=(const vtkTractographyPoint& hp); //for resizing
 
     double   X[3];    /// position


### PR DESCRIPTION
Fix `vtkTractographyPoint` implicit declaration warning: declare the copy constructor.

Fixes:
```
[57/263] Building CXX object Libs/vtkDMRI/CMakeFiles/vtkDMRIPython.dir/vtkTractographyPointAndArrayPython.cxx.o
SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkTractographyPointAndArrayPython.cxx:
 In function ‘PyObject* PyvtkTractographyPoint_vtkTractographyPoint_s2(PyObject*, PyObject*)’:
SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkTractographyPointAndArrayPython.cxx:53:63:
 warning: implicitly-declared ‘constexpr vtkTractographyPoint::vtkTractographyPoint(const vtkTractographyPoint&)’ is deprecated [-Wdeprecated-copy]
   53 |     vtkTractographyPoint *op = new vtkTractographyPoint(*temp0);
      |                                                               ^
In file included from SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkTractographyPointAndArrayPython.cxx:10:
SlicerDMRI/SlicerDMRI/Libs/vtkDMRI/vtkTractographyPointAndArray.h:30:27:
 note: because ‘vtkTractographyPoint’ has user-provided ‘vtkTractographyPoint& vtkTractographyPoint::operator=(const vtkTractographyPoint&)’
   30 |     vtkTractographyPoint &operator=(const vtkTractographyPoint& hp); //for resizing
      |                           ^~~~~~~~
SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkTractographyPointAndArrayPython.cxx:
 In function ‘void* PyvtkTractographyPoint_CCopy(const void*)’:
SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkTractographyPointAndArrayPython.cxx:180:83:
 warning: implicitly-declared ‘constexpr vtkTractographyPoint::vtkTractographyPoint(const vtkTractographyPoint&)’ is deprecated [-Wdeprecated-copy]
  180 |     return new vtkTractographyPoint(*static_cast<const vtkTractographyPoint*>(obj));
      |                                                                                   ^
In file included from SlicerDMRI/SlicerDMRI-build/inner-build/Libs/vtkDMRI/vtkTractographyPointAndArrayPython.cxx:10:
SlicerDMRI/SlicerDMRI/Libs/vtkDMRI/vtkTractographyPointAndArray.h:30:27:
 note: because ‘vtkTractographyPoint’ has user-provided ‘vtkTractographyPoint& vtkTractographyPoint::operator=(const vtkTractographyPoint&)’
   30 |     vtkTractographyPoint &operator=(const vtkTractographyPoint& hp); //for resizing
      |                           ^~~~~~~~
```

raised for example at:
https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/6686457985/job/18165832119#step:7:310