### PR TITLE
COMP: Remove unused `topCluster` var from `FiberTractMeasurements`

### DIFF
--- a/Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx
+++ b/Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx
@@ -560,13 +560,11 @@ void printTable(std::ostream &ofs, bool printHeader,
     {
 
     // find if this cluster in any other cluster
-    bool topCluster = true;
     std::map<std::string, std::string>::iterator itClusterNames1;
     for (itClusterNames1 = ClusterNames.begin(); itClusterNames1!= ClusterNames.end(); itClusterNames1++)
       {
       if (isInCluster(it->first, itClusterNames1->first) )
         {
-        topCluster = false;
         break;
         }
       }


### PR DESCRIPTION
Fix the unused `topCluster` variable warning in `FiberTractMeasurements`: remove the variable.

The `topCluster` variable was originally introduced in 798a1e5 and its use became no longer necessary in 9bdd1d3, where it was left behind.

Fixes:
```
Modules/CLI/FiberTractMeasurements/FiberTractMeasurements.cxx:563:10:
 warning: variable ‘topCluster’ set but not used [-Wunused-but-set-variable]
     bool topCluster = true;
          ^~~~~~~~~~
```

reported on the 3D Slicer CDash server in the context of `preview` builds on CentOS 7 with GCC 7:
https://slicer.cdash.org/viewBuildError.php?type=1&buildid=3210886