### PR TITLE
DOC: Add a link to the Doxygen documentation GitHub Pages URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 [![GitHub release](https://img.shields.io/github/release/SlicerDMRI/SlicerDMRI.svg)](https://github.com/SlicerDMRI/SlicerDMRI/releases/latest)
 [![Build, test](https://github.com/SlicerDMRI/SlicerDMRI/actions/workflows/build-test.yml/badge.svg?branch=master)](https://github.com/SlicerDMRI/SlicerDMRI/actions/workflows/build-test.yml?query=branch%3Amaster)
+[![GitHub release](https://github.com/SlicerDMRI/SlicerDMRI/actions/workflows/pages/pages-build-deployment/badge.svg)](https://dmri.slicer.org/SlicerDMRI/)
 
 Diffusion MRI in 3D Slicer open-source medical imaging software
 
-Website: http://slicerdmri.github.io/
-
-Wiki: https://github.com/SlicerDMRI/SlicerDMRI/wiki
+- **Website**: http://slicerdmri.github.io/
+- **Documentation**: https://dmri.slicer.org/SlicerDMRI/
+- **Wiki**: https://github.com/SlicerDMRI/SlicerDMRI/wiki
 
 CDash for extensions: [http://slicer.cdash.org](http://slicer.cdash.org/index.php?project=Slicer4&filtercount=2&showfilters=1&filtercombine=or&field1=label&compare1=63&value1=SlicerDMRI&field2=label&compare2=63&value2=UKFTractography)
 


### PR DESCRIPTION
Add a link to the Doxygen documentation GitHub Pages URL in the `README` file.

Take advantage of the commit to make the website, documentation and wiki links more visible using a list and bold font.

Add the GitHub Pages deployment status badge.