### PR TITLE
BUG: Fix syntax errors raised after introducing f-strings

### DIFF
--- a/Modules/Scripted/DMRIPlugins/DICOMDiffusionVolumePlugin.py
+++ b/Modules/Scripted/DMRIPlugins/DICOMDiffusionVolumePlugin.py
@@ -112,7 +112,7 @@ class DICOMDiffusionVolumePluginClass(DICOMPlugin):
       loadable.files = files
       loadable.name = name + ' - as DWI Volume'
       loadable.selected = True
-      loadable.tooltip = f"Matches DICOM tags for the following vendor(s): {', '.join(matchingVendors)}")
+      loadable.tooltip = f"Matches DICOM tags for the following vendor(s): {', '.join(matchingVendors)}"
       loadable.confidence = 0.6
       loadables = [loadable]
     return loadables

--- a/Modules/Scripted/TractographyExportPLY/TractographyExportPLY.py
+++ b/Modules/Scripted/TractographyExportPLY/TractographyExportPLY.py
@@ -303,6 +303,6 @@ class TractographyExportPLYTest(ScriptedLoadableModuleTest):
     except Exception as e:
       import traceback
       traceback.print_exc()
-      self.delayDisplay(f"Test caused exception!\n"{str(e)}")
+      self.delayDisplay(f"Test caused exception!\n{str(e)}")
 
 


### PR DESCRIPTION
Fix syntax errors raised after introducing f-strings.

Fixes:
```
SlicerDMRI-build/inner-build/lib/Slicer-5.7/qt-scripted-modules/DICOMDiffusionVolumePlugin.py, line 115
    loadable.tooltip = f"Matches DICOM tags for the following vendor(s): {', '.join(matchingVendors)}")
                                                                                                      ^
SyntaxError: unmatched ')'
```

and
```
SlicerDMRI-build/inner-build/lib/Slicer-5.7/qt-scripted-modules/TractographyExportPLY.py, line 306
   self.delayDisplay(f"Test caused exception!\n"{str(e)}")
                                                ^
SyntaxError: invalid syntax
```

raised for example at:
https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/7130356243/job/19416548387#step:8:541 https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/7130356243/job/19416548387#step:8:559

Introduced inadvertently in commit 56b282f.