### PR TITLE
BUG: Fix syntax errors raised after introducing f-strings (follow-up)

### DIFF
--- a/Modules/Scripted/DICOM2FullBrainTractography/DICOM2FullBrainTractographyLib/workflow_support.py
+++ b/Modules/Scripted/DICOM2FullBrainTractography/DICOM2FullBrainTractographyLib/workflow_support.py
@@ -236,6 +236,7 @@ for volume_type in __VOLUME_TYPES__:
                 f'lambda attach_display_node=False, dimensions=None, prefix="":\
                 create_volume_node( "{volume_type}", attach_display_node=attach_display_node, dimensions=dimensions, prefix=prefix)'
                )
+    )
 
     this_module.__all__.append(function_name)
 


### PR DESCRIPTION
Fix syntax errors raised after introducing f-strings.

Fixes:
```
Compiling qt-scripted-modules/DICOM2FullBrainTractographyLib/workflow_support.py ...
  File "qt-scripted-modules/DICOM2FullBrainTractographyLib/workflow_support.py", line 240
    this_module.__all__.append(function_name)
    ^
SyntaxError: invalid syntax
```

raised for example at:
https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/7132804489/job/19424129633?pr=224#step:7:272

Introduced inadvertently in commit 56b282f and left behind in ee1f772.