### PR TITLE
BUG: Fix data download URLs in tests

### DIFF
--- a/DMRIModuleTemplates/DWI_Scripted/TemplateKey.py
+++ b/DMRIModuleTemplates/DWI_Scripted/TemplateKey.py
@@ -222,7 +222,7 @@ class TemplateKeyTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       nodeNames='FA',
       fileNames='FA.nrrd',
-      uris='http://slicer.kitware.com/midas3/download?items=5767')
+      uris='https://github.com/Slicer/SlicerTestingData/releases/download/SHA256/12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="FA")

--- a/DMRIModuleTemplates/Tractography_Scripted/TemplateKey.py
+++ b/DMRIModuleTemplates/Tractography_Scripted/TemplateKey.py
@@ -230,7 +230,7 @@ class TemplateKeyTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       nodeNames='FA',
       fileNames='FA.nrrd',
-      uris='http://slicer.kitware.com/midas3/download?items=5767')
+      uris='https://github.com/Slicer/SlicerTestingData/releases/download/SHA256/12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
 
     volumeNode = slicer.util.getNode(pattern="FA")

--- a/Modules/Loadable/TractographyDisplay/Testing/Python/SlicerMRBTest.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/SlicerMRBTest.py
@@ -68,8 +68,9 @@ execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Pyt
     #
     if self.useCase == 'small':
       downloads = (
-          ('FA', 'FA.nrrd', 'http://slicer.kitware.com/midas3/download?items=5767', 'VolumeFile'),
-          ('tract1', 'tract1.vtk', 'http://slicer.kitware.com/midas3/download?items=5768', 'FiberBundleFile'),
+           # Setting here the correct links not seem to solve all issues
+          ('FA', 'FA.nrrd', 'https://github.com/Slicer/SlicerTestingData/releases/download/SHA256/12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560', 'VolumeFile'),
+          ('tract1', 'tract1.vtk', 'https://github.com/Slicer/slicer.kitware.com-midas3-archive/releases/download/SHA256/06d5b5777915857fbac7b3cbd9c371523d1371f29b0c89eb7a33d86d780d5b2b', 'FiberBundleFile'),
           )
       tracts = ('tract1',)
       tractColors = ( (0.2, 0.9, 0.3), )
@@ -78,13 +79,13 @@ execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Pyt
           (
             (None, 'DTIVolume'),
             ('DTIVolume.raw.gz', 'DTIVolume.nhdr'),
-            ('http://slicer.kitware.com/midas3/download?items=5766', 'http://slicer.kitware.com/midas3/download?items=5765'),
+            ('https://github.com/Slicer/slicer.kitware.com-midas3-archive/releases/download/SHA256/7bc095de85275609135617bf0026f124d8f7680d0fb8b4aa70c0c9e2565f4b94', 'https://github.com/Slicer/slicer.kitware.com-midas3-archive/releases/download/SHA256/2116f09b145a66c4f36157bea4928dc9c0078374d0e8a902d99ca9ef159bb1e9'),
             'VolumeFile'
           ),
-          ('FA', 'FA.nrrd', 'http://slicer.kitware.com/midas3/download?items=5767', 'VolumeFile'),
-          ('tract1', 'tract1.vtk', 'http://slicer.kitware.com/midas3/download?items=5768', 'FiberBundleFile'),
-          ('tract2', 'tract2.vtk', 'http://slicer.kitware.com/midas3/download?items=5769', 'FiberBundleFile'),
-          ('tract3', 'tract3.vtk', 'http://slicer.kitware.com/midas3/download?items=5770', 'FiberBundleFile'),
+          ('FA', 'FA.nrrd', 'https://github.com/Slicer/SlicerTestingData/releases/download/SHA256/12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560', 'VolumeFile'),
+          ('tract1', 'tract1.vtk', 'https://github.com/Slicer/slicer.kitware.com-midas3-archive/releases/download/SHA256/06d5b5777915857fbac7b3cbd9c371523d1371f29b0c89eb7a33d86d780d5b2b', 'FiberBundleFile'),
+          ('tract2', 'tract2.vtk', 'https://github.com/Slicer/slicer.kitware.com-midas3-archive/releases/download/SHA256/93c4a33fc2b6da2bdbd881e981042400253c25da133024126ca577467a2e9206', 'FiberBundleFile'),
+          ('tract3', 'tract3.vtk', 'https://github.com/Slicer/slicer.kitware.com-midas3-archive/releases/download/SHA256/cf2690b249d7d866de5fbace353e6e00c6705f40f2cbcb1f188781d64d4f8dc0', 'FiberBundleFile'),
           )
       tracts = ('tract1', 'tract2', 'tract3',)
       tractColors = ( (0.2, 0.9, 0.3), (0.9, 0.3, 0.3), (0.2, 0.4, 0.9) )

--- a/Modules/Loadable/TractographyDisplay/Testing/Python/fiber_visibility_crash2438.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/fiber_visibility_crash2438.py
@@ -186,7 +186,7 @@ class fiber_visibility_crash2438Test(unittest.TestCase):
     SampleData.downloadFromURL(
       nodeNames='tract1',
       fileNames='tract1.vtk',
-      uris='http://slicer.kitware.com/midas3/download?items=5768',
+      uris='https://github.com/Slicer/slicer.kitware.com-midas3-archive/releases/download/SHA256/06d5b5777915857fbac7b3cbd9c371523d1371f29b0c89eb7a33d86d780d5b2b',
       loadFileTypes='FiberBundleFile')
     self.delayDisplay('Finished with download and loading\n')
 

--- a/Modules/Loadable/TractographyDisplay/Testing/Python/test_tractography_display.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/test_tractography_display.py
@@ -146,7 +146,7 @@ class test_tractography_displayTest(unittest.TestCase):
     SampleData.downloadFromURL(
       nodeNames='tract1',
       fileNames='tract1.vtk',
-      uris='http://slicer.kitware.com/midas3/download?items=5768',
+      uris='https://github.com/Slicer/slicer.kitware.com-midas3-archive/releases/download/SHA256/06d5b5777915857fbac7b3cbd9c371523d1371f29b0c89eb7a33d86d780d5b2b',
       loadFileTypes='FiberBundleFile')
     self.delayDisplay('Finished with download and loading\n')
 

--- a/Modules/Scripted/FiberBundleToLabelMap/FiberBundleToLabelMap.py
+++ b/Modules/Scripted/FiberBundleToLabelMap/FiberBundleToLabelMap.py
@@ -297,8 +297,8 @@ class FiberBundleToLabelMapTest(unittest.TestCase):
     # first, get some data
     #
     downloads = (
-        ('FA', 'FA.nrrd', 'http://slicer.kitware.com/midas3/download?items=5767', 'VolumeFile'),
-        ('tract1', 'tract1.vtk', 'http://slicer.kitware.com/midas3/download?items=5768', 'FiberBundleFile'),
+        ('FA', 'FA.nrrd', 'https://github.com/Slicer/SlicerTestingData/releases/download/SHA256/12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560', 'VolumeFile'),
+        ('tract1', 'tract1.vtk', 'https://github.com/Slicer/slicer.kitware.com-midas3-archive/releases/download/SHA256/06d5b5777915857fbac7b3cbd9c371523d1371f29b0c89eb7a33d86d780d5b2b', 'FiberBundleFile'),
         )
     import SampleData
     for nodeNames, fileNames, uris, loadFileTypes  in downloads:


### PR DESCRIPTION
Fix data download URLs in tests: the Slicer testing data was moved from kitware midas hosting to GitHub repositories. Related thread: https://github.com/Slicer/Slicer/pull/4785

Fixes:
```
12: ERROR: test_fiber_visibility_crash24381 (fiber_visibility_crash2438.fiber_visibility_crash2438Test)
12: Ideally you should have several levels of tests.  At the lowest level
12: ----------------------------------------------------------------------
12: Traceback (most recent call last):
12:   File "SlicerDMRI/Modules/Loadable/TractographyDisplay/Testing/Python/fiber_visibility_crash2438.py",
 line 203, in test_fiber_visibility_crash24381
12:     tractNode = slicer.util.getNode('tract1')
12:   File "Slicer-build/bin/Python/slicer/util.py", line 1566, in getNode
12:     raise MRMLNodeNotFoundException("could not find nodes in the scene by name or id '%s'" % (pattern if (isinstance(pattern, str)) else ""))
12: slicer.util.MRMLNodeNotFoundException: could not find nodes in the scene by name or id 'tract1'
```

and similar errors raised for example at
https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/7144096978/job/19456990401#step:8:1568

Fixes #207.