### PR TITLE
BUG: handle scalar colors when fibers are unstructured grid

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayWidget.cxx
+++ b/Modules/Loadable/TractographyDisplay/Widgets/qSlicerTractographyDisplayWidget.cxx
@@ -706,7 +706,7 @@ void qSlicerTractographyDisplayWidget::updateWidgetFromMRML()
     (d->FiberBundleDisplayNode->GetColorNodeID());
 
   bool wasBlockingColorByScalarComboBox = d->ColorByScalarComboBox->blockSignals(true);
-  d->ColorByScalarComboBox->setDataSet(vtkDataSet::SafeDownCast(d->FiberBundleNode->GetPolyData()));
+  d->ColorByScalarComboBox->setDataSet(vtkDataSet::SafeDownCast(d->FiberBundleNode->GetMesh()));
   d->ColorByScalarComboBox->blockSignals(wasBlockingColorByScalarComboBox);
 
   bool hasTensors = false;


### PR DESCRIPTION
Since a vtkMRMLModelNode can be either a vtkPolyData or a vtkUnstructuredGrid, use the generic GetMesh method to set the value for the scalar selection combobox.

Fixes #227 