### PR TITLE
ENH: Set scalar range values in tractography display node test

### DIFF
--- a/Modules/Loadable/TractographyDisplay/Testing/Python/test_tractography_display.py
+++ b/Modules/Loadable/TractographyDisplay/Testing/Python/test_tractography_display.py
@@ -256,8 +256,10 @@ class test_tractography_displayTest(unittest.TestCase):
         autoWL.click()
 
     slider = slicer.util.findChildren(tubeTab, name='FiberBundleColorRangeWidget')[0]
+    displayNode.SetAutoScalarRange(False)
     slider.setMinimumValue(.1)
     slider.setMaximumValue(.8)
+    displayNode.SetScalarRange(.1, .8)
     scalar_range = displayNode.GetScalarRange()
     self.assertEqual(scalar_range[0], .1)
     self.assertEqual(scalar_range[1], .8)


### PR DESCRIPTION
Set scalar range values in tractography display node test:
- Set the auto mode to `False`.
- Set the range values explicitly.

Fixes:
```
13: test_TestWindowLevel (test_tractography_display.test_tractography_displayTest) ... FAIL
13:
13: ======================================================================
13: FAIL: test_TestWindowLevel (test_tractography_display.test_tractography_displayTest)
13: ----------------------------------------------------------------------
13: Traceback (most recent call last):
13:   File "SlicerDMRI/Modules/Loadable/TractographyDisplay/Testing/Python/test_tractography_display.py",
 line 262, in test_TestWindowLevel
13:     self.assertEqual(scalar_range[0], .1)
13: AssertionError: 0.0 != 0.1
```

raised for example in:
https://github.com/SlicerDMRI/SlicerDMRI/actions/runs/7223184160/job/19681721059#step:8:1690