### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,10 @@ set(EXTENSION_NAME SlicerDMRI)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://dmri.slicer.org/")
 set(EXTENSION_CATEGORY "Diffusion")
-set(EXTENSION_CONTRIBUTORS "Isaiah Norton, Lauren O'Donnell (Brigham & Women's Hospital)")
-set(EXTENSION_DESCRIPTION "SlicerDMRI is an umbrella extension for Slicer Diffusion MRI functionality.")
-set(EXTENSION_ICONURL "http://raw.githubusercontent.com/SlicerDMRI/slicerdmri.github.io/master/images/DMRI_3D_SLICER-icon.png")
-set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/slicerWiki/images/0/09/SlicerDMRIScreenshot.jpg")
+set(EXTENSION_CONTRIBUTORS "Lauren O'Donnell (Brigham & Women's Hospital), Isaiah Norton (Brigham & Women's Hospital), Fan Zhang (Brigham & Women's Hospital), Alex Yarmarkovich (Brigham & Women's Hospital), Jon Haitz Legarreta Gorroño (Brigham & Women's Hospital)")
+set(EXTENSION_DESCRIPTION "SlicerDMRI provides tools to load diffusion MRI image data, perform tractography, and quantify results.")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/SlicerDMRI/slicerdmri.github.io/master/images/DMRI_3D_SLICER-icon.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/SlicerDMRI/slicerdmri.github.io/master/images/DMRI_3D_SLICER.jpg")
 set(EXTENSION_DEPENDS "UKFTractography") # Specified as a space separated list or 'NA' if any
 set(EXTENSION_BUILD_SUBDIRECTORY inner-build)
 


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.