### PR TITLE
Solved a crash

### DIFF
--- a/Libs/vtkDMRI/vtkTractographyPointAndArray.cxx
+++ b/Libs/vtkDMRI/vtkTractographyPointAndArray.cxx
@@ -54,6 +54,7 @@ vtkTractographyPoint& vtkTractographyPoint::operator=(const vtkTractographyPoint
   this->SubId = hp.SubId;
   this->S = hp.S;
   this->D = hp.D;
+  this->IndexInArray = hp.IndexInArray;
 
   return *this;
 }

--- a/Libs/vtkDMRI/vtkTractographyPointAndArray.h
+++ b/Libs/vtkDMRI/vtkTractographyPointAndArray.h
@@ -27,7 +27,7 @@
 class vtkDMRI_EXPORT vtkTractographyPoint { //;prevent man page generation
 public:
     vtkTractographyPoint(); /// method sets up storage
-    vtkTractographyPoint(const vtkTractographyPoint &) = default;
+	vtkTractographyPoint(const vtkTractographyPoint &) = default;
     vtkTractographyPoint &operator=(const vtkTractographyPoint& hp); //for resizing
 
     double   X[3];    /// position
@@ -45,6 +45,7 @@ public:
     double   T0[3];   /// storage for tensor
     double   T1[3];
     double   T2[3];
+    int      IndexInArray{ -1 };
 };
 
 class vtkDMRI_EXPORT vtkTractographyArray { //;prevent man page generation
@@ -61,11 +62,14 @@ public:
   vtkTractographyPoint *GetTractographyPoint(vtkIdType i) {return this->Array + i;};
   vtkTractographyPoint *InsertNextTractographyPoint()
     {
+      vtkTractographyPoint* res = nullptr;
     if ( ++this->MaxId >= this->Size )
       {
       this->Resize(this->MaxId);
       }
-    return this->Array + this->MaxId;
+    res = this->Array + this->MaxId;
+    res->IndexInArray = MaxId;
+    return res;
     }
   vtkTractographyPoint *Resize(vtkIdType sz); //reallocates data
   void Reset() {this->MaxId = -1;};


### PR DESCRIPTION
Solves the problem of pointer hanging when generating a large number of fiber bundles.

An IndexInArray member has been added to the vtkTractographyPoint class to record the index of the current point in the array, and the related assignment operation has been improved. Save index in advance when updating array memory to avoid dangling Pointers.