### PR TITLE
BUG: refactor vtk class memory allocation

### DIFF
--- a/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
+++ b/Modules/Loadable/TractographyDisplay/MRML/vtkMRMLFiberBundleNode.h
@@ -38,6 +38,8 @@ class vtkMRMLFiberBundleDisplayNode;
 class vtkMRMLMarkupsNode;
 class vtkPassThrough;
 class vtkPlanes;
+class vtkSelection;
+class vtkSelectionNode;
 
 class VTK_SLICER_TRACTOGRAPHYDISPLAY_MODULE_MRML_EXPORT vtkMRMLFiberBundleNode : public vtkMRMLModelNode
 {
@@ -224,6 +226,11 @@ private:
   vtkGeometryFilter* GeometryFilter;
   vtkPlanes *Planes;
   vtkPassThrough* LocalPassThrough;
+
+  // for subsampling
+  vtkSelection* Selection;
+  vtkSelectionNode* SelectionNode;
+  vtkIdTypeArray* IdsOfCellsToKeep;
 
   // Internal methods
   void UpdateSubsampling();


### PR DESCRIPTION
vtkNew allocates pointers to vtk class instances on the stack, so they are freed when the variables go out of scope.  This led to crashes when trying to use them from other methods.

This no allocates class instances consistently so they can be re-used safely and only deleted when the node is freed up.