### PR TITLE
BUG: Fix remaining bare cout/cerr/endl without std:: prefix

### DIFF
--- a/Libs/vtkDMRI/vtkImageGetTensorComponents.cxx
+++ b/Libs/vtkDMRI/vtkImageGetTensorComponents.cxx
@@ -120,7 +120,7 @@ static void vtkImageGetTensorComponentsExecute(vtkImageGetTensorComponents *self
   offset[3]=4;
   offset[4]=5;
   offset[5]=8;
-//  cout << "off0 " << offset[0] << endl;
+//  std::cout << "off0 " << offset[0] << std::endl;
   for (idxZ = 0; idxZ <= maxZ; idxZ++)
     {
     for (idxY = 0; !self->AbortExecute && idxY <= maxY; idxY++)

--- a/Libs/vtkDMRI/vtkImageSetTensorComponents.cxx
+++ b/Libs/vtkDMRI/vtkImageSetTensorComponents.cxx
@@ -157,7 +157,7 @@ static void vtkImageSetTensorComponentsExecute(vtkImageSetTensorComponents *self
         }
       for (idxR = 0; idxR <= maxX; idxR++)
         {
-        //cout << idxR << " " << idxY << " " << idxZ << " " << ptId << endl;
+        //std::cout << idxR << " " << idxY << " " << idxZ << " " << ptId << std::endl;
       outT[0][0]=(float)*inPtr++;
 
       outT[0][1]=(float)*inPtr;

--- a/Libs/vtkDMRI/vtkPreciseHyperStreamlinePoints.cxx
+++ b/Libs/vtkDMRI/vtkPreciseHyperStreamlinePoints.cxx
@@ -135,9 +135,9 @@ int vtkPreciseHyperStreamlinePoints::RequestData(vtkInformation* request,
         {
           //for (j=0; j<3; j++) // grab point's coordinates
           //{
-          //cout << sPtr->X[j] << " ";
+          //std::cout << sPtr->X[j] << " ";
           //}
-          //cout << endl;
+          //std::cout << std::endl;
 
           this->PreciseHyperStreamlines[ptId]->InsertPoint(i,sPtr->X);
           npts++;

--- a/Libs/vtkDMRI/vtkSeedTracts.cxx
+++ b/Libs/vtkDMRI/vtkSeedTracts.cxx
@@ -530,8 +530,8 @@ void vtkSeedTracts::SeedStreamlinesInROI()
   maxY = inExt[3] - inExt[2];
   maxZ = inExt[5] - inExt[4];
 
-  //cout << "Dims: " << maxX << " " << maxY << " " << maxZ << endl;
-  //cout << "Incr: " << inIncX << " " << inIncY << " " << inIncZ << endl;
+  //std::cout << "Dims: " << maxX << " " << maxY << " " << maxZ << std::endl;
+  //std::cout << "Incr: " << inIncX << " " << inIncY << " " << inIncZ << std::endl;
 
   // If we are iterating over a non-voxel (isotropic) grid, change the increments
   // to reflect this.  So we want to iterate in voxel (IJK) space still, but with
@@ -1022,8 +1022,8 @@ void vtkSeedTracts::SeedStreamlinesFromROIIntersectWithROI2()
   maxY = inExt[3] - inExt[2];
   maxZ = inExt[5] - inExt[4];
 
-  //cout << "Dims: " << maxX << " " << maxY << " " << maxZ << endl;
-  //cout << "Incr: " << inIncX << " " << inIncY << " " << inIncZ << endl;
+  //std::cout << "Dims: " << maxX << " " << maxY << " " << maxZ << std::endl;
+  //std::cout << "Incr: " << inIncX << " " << inIncY << " " << inIncZ << std::endl;
 
   // for progress notification
   //target = (unsigned long)((maxZ+1)*(maxY+1)/50.0);

--- a/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx
+++ b/Libs/vtkDMRI/vtkTeemEstimateDiffusionTensor.cxx
@@ -159,7 +159,7 @@ void vtkTeemEstimateDiffusionTensor::TransformDiffusionGradients()
     }
 
   vtkDebugMacro("Transforming diffusion gradients");
-  //this->Transform->Print(cout);
+  //this->Transform->Print(std::cout);
 
 
   // transform each gradient by this matrix

--- a/Modules/CLI/TractographyLabelMapSeeding/TractographyLabelMapSeeding.cxx
+++ b/Modules/CLI/TractographyLabelMapSeeding/TractographyLabelMapSeeding.cxx
@@ -100,7 +100,7 @@ int main( int argc, char * argv[] )
         }
       else
         {
-        std::cerr << "Mode " << ThresholdMode << " is not supported" << endl;
+        std::cerr << "Mode " << ThresholdMode << " is not supported" << std::endl;
         return EXIT_FAILURE;
         }
 
@@ -231,7 +231,7 @@ int main( int argc, char * argv[] )
       }
     else
       {
-      std::cerr << "Mode " << ThresholdMode << " is not supported" << endl;
+      std::cerr << "Mode " << ThresholdMode << " is not supported" << std::endl;
       return EXIT_FAILURE;
       }
 
@@ -262,7 +262,7 @@ int main( int argc, char * argv[] )
       {
       if (fileExtension != ".vtp")
         {
-        cerr << "Extension not recognize, saving the information in VTP format" << endl;
+        std::cerr << "Extension not recognize, saving the information in VTP format" << std::endl;
         }
       vtkNew<vtkXMLPolyDataWriter> writer;
       writer->SetFileName(OutputFibers.c_str() );
@@ -272,7 +272,7 @@ int main( int argc, char * argv[] )
   }
   catch( ... )
     {
-    cout << "default exception";
+    std::cout << "default exception";
     return EXIT_FAILURE;
     }
 

--- a/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.cxx
+++ b/Modules/Loadable/TractographyDisplay/MRMLDM/vtkMRMLTractographyDisplayDisplayableManager.cxx
@@ -86,7 +86,7 @@ vtkMRMLTractographyDisplayDisplayableManager::~vtkMRMLTractographyDisplayDisplay
 //---------------------------------------------------------------------------
 void vtkMRMLTractographyDisplayDisplayableManager::PrintSelf(std::ostream &os, vtkIndent indent)
 {
-  os<<indent<<"Print logic"<<endl;
+  os<<indent<<"Print logic"<<std::endl;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Follow-up to #253 — qualify all remaining bare `cout`, `cerr`, and `endl` with `std::` prefix
- Includes both active code and commented-out code, for consistency and so uncommenting works without changes
- Fixes build failure in `TractographyLabelMapSeeding` on Linux with VTK 9.6

## Test plan
- [x] Verify Linux extension build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)