### PR TITLE
ENH: Install tractcloud from main branch

### DIFF
--- a/Modules/Scripted/TractCloud/README.md
+++ b/Modules/Scripted/TractCloud/README.md
@@ -45,22 +45,6 @@ On first use the module automatically downloads pre-trained model weights
   https://github.com/SlicerDMRI/TractCloud
 - GPU (CUDA) is used automatically when available
 
-### Testing with the development branch
-
-To test the TractCloud module before the `tractcloud` package is merged
-to `main`, install the `inference-cli` branch into Slicer's Python:
-
-```python
-# In Slicer's Python console:
-slicer.util.pip_install("git+https://github.com/SlicerDMRI/TractCloud.git@inference-cli")
-```
-
-Or from the command line:
-
-```bash
-PythonSlicer -m pip install "git+https://github.com/SlicerDMRI/TractCloud.git@inference-cli"
-```
-
 ### Output tracts (42)
 
 | Category | Tracts |

--- a/Modules/Scripted/TractCloud/TractCloud.py
+++ b/Modules/Scripted/TractCloud/TractCloud.py
@@ -214,7 +214,7 @@ class TractCloudLogic(ScriptedLoadableModuleLogic):
             self._status("Installing tractcloud package...")
             slicer.util.pip_install(
                 "https://github.com/SlicerDMRI/TractCloud/"
-                "archive/inference-cli.zip")
+                "archive/main.zip")
 
     def run(self, inputNode, includeOther=False, device="auto",
             batchSize=2048):


### PR DESCRIPTION
## Summary
- Update pip install URL from `inference-cli` branch to `main` (now merged)
- Remove dev branch testing instructions from README

Follow-up to #252 and #255.